### PR TITLE
Fix/empty username validation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -377,8 +377,11 @@
           <div class="input-row">
             <div class="input-group">
               <label for="username">GitHub Username</label>
-              <input id="username" name="username" type="text" value="SamXop123" autocomplete="off" spellcheck="false"
-                placeholder="Enter your username" />
+              <input id="username" name="username" type="text" value="" autocomplete="off" spellcheck="false"
+                placeholder="Enter your GitHub username" />
+              <p id="username-error" style="color: #f87171; font-size: 0.8rem; margin-top: 4px; display: none;">
+                Please enter a GitHub username to preview.
+              </p>
             </div>
             <div class="input-group">
               <label for="theme-select">Theme</label>

--- a/public/script.js
+++ b/public/script.js
@@ -48,6 +48,27 @@
     }
   }
 
+  /* Updates only the markdown snippet in real-time without reloading the preview image */
+  function updateSnippetOnly() {
+    const username = usernameInput.value.trim() || 'SamXop123';
+    const leetcode = leetcodeInput.value.trim();
+    const theme = themeSelect.value;
+    const align = alignSelect.value;
+    const hideTrophies = hideTrophiesCheck ? hideTrophiesCheck.checked : false;
+
+    const params = new URLSearchParams({ username });
+    if (theme) params.append('theme', theme);
+    if (leetcode) params.append('leetcode', leetcode);
+    if (align && align !== 'left') params.append('align', align);
+    if (hideTrophies) params.append('hide_trophies', 'true');
+
+    const publicUrl = `${deployUrl}/api/profile?${params.toString()}`;
+
+    if (snippet) {
+      snippet.textContent = `![samdev-pulse](${publicUrl})`;
+    }
+  }
+
   /* Handles the update preview button click */
   function handleUpdateClick() {
     if (!updateBtn) return;
@@ -112,6 +133,30 @@
     });
   }
 
+  /* Sets up real-time listeners so the markdown snippet stays
+     in sync with all input changes instantly, without requiring
+     the user to click "Update Preview" */
+  function setupRealTimeSync() {
+    // Typing in username or leetcode fields updates snippet instantly
+    if (usernameInput) {
+      usernameInput.addEventListener('input', updateSnippetOnly);
+    }
+    if (leetcodeInput) {
+      leetcodeInput.addEventListener('input', updateSnippetOnly);
+    }
+
+    // Changing theme, alignment, or hide-trophies updates snippet instantly
+    if (themeSelect) {
+      themeSelect.addEventListener('change', updateSnippetOnly);
+    }
+    if (alignSelect) {
+      alignSelect.addEventListener('change', updateSnippetOnly);
+    }
+    if (hideTrophiesCheck) {
+      hideTrophiesCheck.addEventListener('change', updateSnippetOnly);
+    }
+  }
+
   /* this function initialize all event listeners */
   function init() {
     if (updateBtn) {
@@ -123,6 +168,9 @@
     }
 
     setupSmoothScrolling();
+
+    // Set up real-time snippet sync on every input change
+    setupRealTimeSync();
 
     updatePreview();
   }

--- a/public/script.js
+++ b/public/script.js
@@ -71,28 +71,43 @@
 
   /* Handles the update preview button click */
   function handleUpdateClick() {
-    if (!updateBtn) return;
+  if (!updateBtn) return;
 
-    updateBtn.disabled = true;
+  const username = usernameInput.value.trim();
+  const errorMsg = document.getElementById('username-error');
+
+  // Show validation message if username is empty
+  if (!username) {
+    if (errorMsg) {
+      errorMsg.style.display = 'block';
+      usernameInput.focus();
+    }
+    return; // Stop here — don't make API call
+  }
+
+  // Hide error if username is now filled
+  if (errorMsg) errorMsg.style.display = 'none';
+
+  updateBtn.disabled = true;
+  updateBtn.innerHTML = `
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2"/>
+    </svg>
+    Updating...
+  `;
+
+  updatePreview();
+
+  setTimeout(() => {
+    updateBtn.disabled = false;
     updateBtn.innerHTML = `
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
         <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2"/>
       </svg>
-      Updating...
+      Update Preview
     `;
-
-    updatePreview();
-
-    setTimeout(() => {
-      updateBtn.disabled = false;
-      updateBtn.innerHTML = `
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2"/>
-        </svg>
-        Update Preview
-      `;
-    }, 500);
-  }
+  }, 500);
+}
 
   /* Handles copy button click */
   async function handleCopyClick() {
@@ -139,7 +154,13 @@
   function setupRealTimeSync() {
     // Typing in username or leetcode fields updates snippet instantly
     if (usernameInput) {
-      usernameInput.addEventListener('input', updateSnippetOnly);
+      usernameInput.addEventListener('input', () => {
+        const errorMsg = document.getElementById('username-error');
+        if (errorMsg && usernameInput.value.trim()) {
+          errorMsg.style.display = 'none';
+        }
+        updateSnippetOnly();
+     });
     }
     if (leetcodeInput) {
       leetcodeInput.addEventListener('input', updateSnippetOnly);
@@ -172,7 +193,9 @@
     // Set up real-time snippet sync on every input change
     setupRealTimeSync();
 
-    updatePreview();
+    if (usernameInput && usernameInput.value.trim()) {
+      updateSnippetOnly();
+   }
   }
 
   // runs initialization when DOM is ready


### PR DESCRIPTION
Closes #13

**What was the problem?**
When a new user landed on the live preview section and clicked 
"Update Preview" without entering a username, the tool silently 
loaded the creator's profile with zero feedback. A first-time 
visitor had no idea whose profile they were looking at or that 
they even needed to type their own username. Confusing experience.

**What did I fix?**
Following the maintainer's suggestion, I made three focused changes:

- Removed the hardcoded default username from the input field so 
  it starts empty, giving users a clear prompt to enter their own
- Kept the initial demo preview image hardcoded to show a nice 
  first impression on page load
- Added inline validation — if "Update Preview" is clicked with 
  an empty field, a clear red message appears saying "Please enter 
  a GitHub username to preview" instead of silently falling back

The error message also disappears automatically as soon as the 
user starts typing, keeping the experience smooth and clean.

**Files Changed**
- public/index.html — removed default value, added error message element
- public/script.js — added validation logic in handleUpdateClick()