### PR TITLE
feat(cp): Add Codeforces and CodeChef stats integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@vercel/analytics": "^1.6.1",
         "dotenv": "^17.2.3",
-        "express": "^4.18.2",
+        "express": "^4.22.2",
         "mongoose": "^9.1.6"
       }
     },
@@ -97,9 +97,9 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -110,7 +110,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -318,14 +318,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -344,7 +344,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -470,9 +470,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -793,9 +793,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -928,13 +928,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@vercel/analytics": "^1.6.1",
     "dotenv": "^17.2.3",
-    "express": "^4.18.2",
+    "express": "^4.22.2",
     "mongoose": "^9.1.6"
   }
 }

--- a/src/renderers/cp-section.renderer.js
+++ b/src/renderers/cp-section.renderer.js
@@ -1,0 +1,86 @@
+export function renderCPSection({ x, y, width, leetcode, codeforces, codechef }) {
+  const platforms = [];
+
+  if (leetcode) {
+    platforms.push({
+      title: 'LeetCode',
+      lines: [
+        `Solved: ${leetcode.totalSolved ?? 0}`,
+        `E:${leetcode.easySolved} M:${leetcode.mediumSolved} H:${leetcode.hardSolved}`,
+        `Rating: ${leetcode.contestRating ?? leetcode.ranking ?? 'N/A'}`,
+      ]
+    });
+  }
+
+  if (codeforces) {
+    platforms.push({
+      title: 'Codeforces',
+      lines: [
+        `Rating: ${codeforces.rating}`,
+        `Rank: ${codeforces.rank}`,
+        `Max: ${codeforces.maxRating}`,
+      ]
+    });
+  }
+
+  if (codechef) {
+    platforms.push({
+      title: 'CodeChef',
+      lines: [
+        `Rating: ${codechef.currentRating} ${codechef.stars}`,
+        `Highest: ${codechef.highestRating}`,
+        `Country Rank: ${codechef.countryRank}`,
+      ]
+    });
+  }
+
+  if (platforms.length === 0) return '';
+
+  const colWidth = Math.floor(width / platforms.length);
+
+  const cols = platforms.map((p, i) => `
+    <g transform="translate(${i * colWidth}, 0)">
+      <text
+        font-family="'Segoe UI', sans-serif"
+        font-size="10"
+        font-weight="700"
+        fill="#58a6ff"
+        x="0" y="0"
+        letter-spacing="1">
+        ${p.title.toUpperCase()}
+      </text>
+      ${p.lines.map((line, j) => `
+        <text
+          font-family="'Segoe UI', sans-serif"
+          font-size="11"
+          fill="#c9d1d9"
+          x="0"
+          y="${16 + j * 16}">
+          ${line}
+        </text>
+      `).join('')}
+    </g>
+  `).join('');
+
+  return `
+    <g transform="translate(${x}, ${y})">
+      <text
+        font-family="'Segoe UI', sans-serif"
+        font-size="10"
+        font-weight="600"
+        fill="#8b949e"
+        x="0" y="0"
+        letter-spacing="2">
+        COMPETITIVE PROGRAMMING
+      </text>
+      <line
+        x1="0" y1="8"
+        x2="${width}" y2="8"
+        stroke="#30363d"
+        stroke-width="0.5"/>
+      <g transform="translate(0, 20)">
+        ${cols}
+      </g>
+    </g>
+  `;
+}

--- a/src/renderers/cp-section.renderer.js
+++ b/src/renderers/cp-section.renderer.js
@@ -1,112 +1,205 @@
-import { getColors } from './svg.renderer.js';
+import { getTheme } from './svg.renderer.js';
 
-function renderCPCard({ x, y, width, height, title, accentColor, stats }) {
-  const colors = getColors();
-  const statsContent = stats.map((stat, i) => {
-    const statX = x + 20;
-    const statY = y + 75 + (i * 38);
-    return `
-      <text x="${statX}" y="${statY}" 
-        font-family="'SF Pro Display', -apple-system, sans-serif" 
-        font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">
-        ${stat.label}
-      </text>
-      <text x="${statX}" y="${statY + 18}" 
-        font-family="'SF Pro Display', -apple-system, sans-serif" 
-        font-size="16" font-weight="700" fill="${colors.primaryText}">
-        ${stat.value}
-      </text>`;
-  }).join('');
-
-  return `
-    <g>
-      <rect x="${x}" y="${y}" width="${width}" height="${height}" 
-        rx="12" fill="${colors.cardBg}" 
-        stroke="${colors.border}" stroke-width="1"/>
-      <rect x="${x}" y="${y}" width="${width}" height="4" 
-        rx="2" fill="${accentColor}"/>
-      <text x="${x + 20}" y="${y + 32}" 
-        font-family="'SF Pro Display', -apple-system, sans-serif" 
-        font-size="13" font-weight="600" fill="${colors.secondaryText}" 
-        letter-spacing="0.5">
-        ${title.toUpperCase()}
-      </text>
-      <line x1="${x + 20}" y1="${y + 44}" x2="${x + width - 20}" y2="${y + 44}" 
-        stroke="${colors.border}" stroke-width="0.5"/>
-      ${statsContent}
-    </g>`;
-}
+const CARD_RADIUS = 16;
+const CARD_GAP = 16;
 
 export function renderCPSection({ x, y, width, leetcode, codeforces, codechef }) {
-  const colors = getColors();
+  const { colors } = getTheme();
+
   const platforms = [];
 
   if (leetcode) {
     platforms.push({
-      title: 'LeetCode',
-      accentColor: '#f89f1b',
-      stats: [
-        { label: 'Problems Solved', value: String(leetcode.totalSolved ?? 0) },
-        { label: 'Easy / Medium / Hard', value: `${leetcode.easySolved ?? 0} / ${leetcode.mediumSolved ?? 0} / ${leetcode.hardSolved ?? 0}` },
-        { label: 'Contest Rating', value: String(leetcode.contestRating ?? leetcode.ranking ?? 'N/A') },
-      ]
+      title: 'LeetCode Stats',
+      render: (cx, cy, cw) => renderLeetCodeCard(cx, cy, cw, leetcode, colors),
     });
   }
 
   if (codeforces) {
-    const rank = codeforces.rank ?? 'unrated';
-    const shortRank = rank.split(' ').map(w => w[0].toUpperCase() + w.slice(1)).join(' ');
     platforms.push({
-      title: 'Codeforces',
-      accentColor: '#3b82f6',
-      stats: [
-        { label: 'Rating', value: String(codeforces.rating ?? 0) },
-        { label: 'Max Rating', value: String(codeforces.maxRating ?? 0) },
-        { label: 'Rank', value: shortRank },
-      ]
+      title: 'Codeforces Stats',
+      render: (cx, cy, cw) => renderCodeforcesCard(cx, cy, cw, codeforces, colors),
     });
   }
 
   if (codechef) {
     platforms.push({
-      title: 'CodeChef',
-      accentColor: '#8b5cf6',
-      stats: [
-        { label: 'Rating', value: `${codechef.currentRating ?? 0} ${codechef.stars ?? ''}` },
-        { label: 'Highest Rating', value: String(codechef.highestRating ?? 0) },
-        { label: 'Global Rank', value: String(codechef.globalRank ?? 'N/A') },
-      ]
+      title: 'CodeChef Stats',
+      render: (cx, cy, cw) => renderCodeChefCard(cx, cy, cw, codechef, colors),
     });
   }
 
   if (platforms.length === 0) return '';
 
-  const cardGap = 16;
-  const cardWidth = Math.floor((width - (cardGap * (platforms.length - 1))) / platforms.length);
-  const cardHeight = 180;
+  const totalGaps = (platforms.length - 1) * CARD_GAP;
+  const cardWidth = (width - totalGaps) / platforms.length;
+  const cardHeight = 140;
 
-  const cards = platforms.map((p, i) =>
-    renderCPCard({
-      x: x + i * (cardWidth + cardGap),
-      y: y + 40,
-      width: cardWidth,
-      height: cardHeight,
-      title: p.title,
-      accentColor: p.accentColor,
-      stats: p.stats,
-    })
-  ).join('');
+  const cards = platforms.map((platform, i) => {
+    const cardX = x + i * (cardWidth + CARD_GAP);
+    const cardY = y;
+
+    return `
+      <g>
+        <rect x="${cardX}" y="${cardY}" width="${cardWidth}" height="${cardHeight}"
+          rx="${CARD_RADIUS}" ry="${CARD_RADIUS}"
+          fill="${colors.glow}" opacity="0.04" filter="url(#cardGlow)"/>
+        <rect x="${cardX}" y="${cardY}" width="${cardWidth}" height="${cardHeight}"
+          rx="${CARD_RADIUS}" ry="${CARD_RADIUS}"
+          fill="${colors.cardBackground}"/>
+        <rect x="${cardX}" y="${cardY}" width="${cardWidth}" height="${cardHeight}"
+          rx="${CARD_RADIUS}" ry="${CARD_RADIUS}"
+          fill="url(#mainGradient)" opacity="0.3"/>
+        <rect x="${cardX + 0.5}" y="${cardY + 0.5}" width="${cardWidth - 1}" height="${cardHeight - 1}"
+          rx="${CARD_RADIUS}" ry="${CARD_RADIUS}"
+          fill="none" stroke="${colors.borderLight}" stroke-width="1" opacity="0.4"/>
+        <text
+          x="${cardX + 20}" y="${cardY + 30}"
+          font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+          font-size="13" font-weight="600"
+          fill="${colors.secondaryText}"
+          letter-spacing="0.5">${platform.title.toUpperCase()}</text>
+        <rect x="${cardX + 20}" y="${cardY + 40}" width="28" height="2"
+          rx="1" fill="url(#accentGradient)" opacity="0.7"/>
+        ${platform.render(cardX, cardY, cardWidth)}
+      </g>
+    `;
+  }).join('');
+
+  return `<g>${cards}</g>`;
+}
+
+function renderLeetCodeCard(x, y, width, data, colors) {
+  const statsY = y + 85;
+  const col1X = x + 20;
+  const col2X = x + 20 + (width - 40) / 3;
+  const col3X = x + 20 + ((width - 40) / 3) * 2;
+
+  const solved = String(data.totalSolved ?? 0);
+  const rating = String(data.contestRating ?? data.ranking ?? 'N/A');
 
   return `
-    <g>
-      <text x="${x}" y="${y + 16}" 
-        font-family="'SF Pro Display', -apple-system, sans-serif" 
-        font-size="13" font-weight="600" fill="${colors.secondaryText}" 
-        letter-spacing="0.5">
-        COMPETITIVE PROGRAMMING
-      </text>
-      <line x1="${x}" y1="${y + 24}" x2="${x + width}" y2="${y + 24}" 
-        stroke="${colors.border}" stroke-width="0.5"/>
-      ${cards}
-    </g>`;
+    <text x="${col1X}" y="${statsY}"
+      font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="32" font-weight="700" fill="${colors.primaryText}">${solved}</text>
+    <text x="${col1X}" y="${statsY + 20}"
+      font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">Solved</text>
+
+    <text x="${col2X}" y="${statsY - 18}"
+      font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="11" font-weight="600" fill="#10b981">E</text>
+    <text x="${col2X + 14}" y="${statsY - 18}"
+      font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="14" font-weight="700" fill="${colors.primaryText}">${data.easySolved ?? 0}</text>
+
+    <text x="${col2X}" y="${statsY}"
+      font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="11" font-weight="600" fill="#f59e0b">M</text>
+    <text x="${col2X + 14}" y="${statsY}"
+      font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="14" font-weight="700" fill="${colors.primaryText}">${data.mediumSolved ?? 0}</text>
+
+    <text x="${col2X}" y="${statsY + 18}"
+      font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="11" font-weight="600" fill="#ef4444">H</text>
+    <text x="${col2X + 14}" y="${statsY + 18}"
+      font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="14" font-weight="700" fill="${colors.primaryText}">${data.hardSolved ?? 0}</text>
+
+    <text x="${col3X}" y="${statsY}"
+      font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="32" font-weight="700" fill="${colors.primaryText}">${rating}</text>
+    <text x="${col3X}" y="${statsY + 20}"
+      font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">Rating</text>
+  `;
+}
+
+function renderCodeforcesCard(x, y, width, data, colors) {
+  const statsY = y + 85;
+  const col1X = x + 20;
+  const col2X = x + 20 + (width - 40) / 3;
+  const col3X = x + 20 + ((width - 40) / 3) * 2;
+
+  const rankMap = {
+    'newbie': 'Newbie',
+    'pupil': 'Pupil',
+    'specialist': 'Specialist',
+    'expert': 'Expert',
+    'candidate master': 'Cand.Master',
+    'master': 'Master',
+    'international master': 'Int.Master',
+    'grandmaster': 'GM',
+    'international grandmaster': 'Int.GM',
+    'legendary grandmaster': 'Leg.GM',
+  };
+
+  const rankShort = rankMap[data.rank?.toLowerCase()] ?? data.rank ?? 'unrated';
+  const maxRankShort = rankMap[data.maxRank?.toLowerCase()] ?? data.maxRank ?? 'unrated';
+
+  return `
+    <text x="${col1X}" y="${statsY}"
+      font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="32" font-weight="700" fill="${colors.primaryText}">${data.rating}</text>
+    <text x="${col1X}" y="${statsY + 20}"
+      font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">Rating</text>
+
+    <text x="${col2X+6}" y="${statsY - 18}"
+      font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="11" font-weight="600" fill="#6366f1">R</text>
+    <text x="${col2X + 18}" y="${statsY - 18}"
+      font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="11" font-weight="700" fill="${colors.primaryText}">${rankShort}</text>
+
+    <text x="${col2X+6}" y="${statsY + 2}"
+      font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="11" font-weight="600" fill="#8b5cf6">MR</text>
+    <text x="${col2X + 26}" y="${statsY + 2}"
+      font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="11" font-weight="700" fill="${colors.primaryText}">${maxRankShort}</text>
+
+    <text x="${col3X+6}" y="${statsY}"
+      font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="32" font-weight="700" fill="${colors.primaryText}">${data.maxRating}</text>
+    <text x="${col3X}" y="${statsY + 20}"
+      font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">Max Rating</text>
+  `;
+}
+
+
+
+function renderCodeChefCard(x, y, width, data, colors) {
+  const statsY = y + 85;
+  const col1X = x + 20;
+  const col2X = x + 20 + (width - 40) / 3;
+  const col3X = x + 20 + ((width - 40) / 3) * 2;
+
+  return `
+    <!-- Current Rating -->
+    <text x="${col1X}" y="${statsY}" 
+      font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="32" font-weight="700" fill="${colors.primaryText}">${data.currentRating}</text>
+    <text x="${col1X}" y="${statsY + 20}"
+      font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">Rating</text>
+
+    <!-- Stars — centered in middle column -->
+    <text x="${col2X+16}" y="${statsY -8}" 
+      font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="22" font-weight="700" fill="#f59e0b">${data.stars ?? ' 1★'}</text>
+    <text x="${col2X+16}" y="${statsY + 20}"
+      font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">Stars</text>
+
+    <!-- Highest Rating -->
+    <text x="${col3X}" y="${statsY}"
+      font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="32" font-weight="700" fill="${colors.primaryText}">${data.highestRating}</text>
+    <text x="${col3X}" y="${statsY + 20}"
+      font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">Highest</text>
+  `;
 }

--- a/src/renderers/cp-section.renderer.js
+++ b/src/renderers/cp-section.renderer.js
@@ -1,24 +1,68 @@
+import { getColors } from './svg.renderer.js';
+
+function renderCPCard({ x, y, width, height, title, accentColor, stats }) {
+  const colors = getColors();
+  const statsContent = stats.map((stat, i) => {
+    const statX = x + 20;
+    const statY = y + 75 + (i * 38);
+    return `
+      <text x="${statX}" y="${statY}" 
+        font-family="'SF Pro Display', -apple-system, sans-serif" 
+        font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">
+        ${stat.label}
+      </text>
+      <text x="${statX}" y="${statY + 18}" 
+        font-family="'SF Pro Display', -apple-system, sans-serif" 
+        font-size="16" font-weight="700" fill="${colors.primaryText}">
+        ${stat.value}
+      </text>`;
+  }).join('');
+
+  return `
+    <g>
+      <rect x="${x}" y="${y}" width="${width}" height="${height}" 
+        rx="12" fill="${colors.cardBg}" 
+        stroke="${colors.border}" stroke-width="1"/>
+      <rect x="${x}" y="${y}" width="${width}" height="4" 
+        rx="2" fill="${accentColor}"/>
+      <text x="${x + 20}" y="${y + 32}" 
+        font-family="'SF Pro Display', -apple-system, sans-serif" 
+        font-size="13" font-weight="600" fill="${colors.secondaryText}" 
+        letter-spacing="0.5">
+        ${title.toUpperCase()}
+      </text>
+      <line x1="${x + 20}" y1="${y + 44}" x2="${x + width - 20}" y2="${y + 44}" 
+        stroke="${colors.border}" stroke-width="0.5"/>
+      ${statsContent}
+    </g>`;
+}
+
 export function renderCPSection({ x, y, width, leetcode, codeforces, codechef }) {
+  const colors = getColors();
   const platforms = [];
 
   if (leetcode) {
     platforms.push({
       title: 'LeetCode',
-      lines: [
-        `Solved: ${leetcode.totalSolved ?? 0}`,
-        `E:${leetcode.easySolved} M:${leetcode.mediumSolved} H:${leetcode.hardSolved}`,
-        `Rating: ${leetcode.contestRating ?? leetcode.ranking ?? 'N/A'}`,
+      accentColor: '#f89f1b',
+      stats: [
+        { label: 'Problems Solved', value: String(leetcode.totalSolved ?? 0) },
+        { label: 'Easy / Medium / Hard', value: `${leetcode.easySolved ?? 0} / ${leetcode.mediumSolved ?? 0} / ${leetcode.hardSolved ?? 0}` },
+        { label: 'Contest Rating', value: String(leetcode.contestRating ?? leetcode.ranking ?? 'N/A') },
       ]
     });
   }
 
   if (codeforces) {
+    const rank = codeforces.rank ?? 'unrated';
+    const shortRank = rank.split(' ').map(w => w[0].toUpperCase() + w.slice(1)).join(' ');
     platforms.push({
       title: 'Codeforces',
-      lines: [
-        `Rating: ${codeforces.rating}`,
-        `Rank: ${codeforces.rank}`,
-        `Max: ${codeforces.maxRating}`,
+      accentColor: '#3b82f6',
+      stats: [
+        { label: 'Rating', value: String(codeforces.rating ?? 0) },
+        { label: 'Max Rating', value: String(codeforces.maxRating ?? 0) },
+        { label: 'Rank', value: shortRank },
       ]
     });
   }
@@ -26,61 +70,43 @@ export function renderCPSection({ x, y, width, leetcode, codeforces, codechef })
   if (codechef) {
     platforms.push({
       title: 'CodeChef',
-      lines: [
-        `Rating: ${codechef.currentRating} ${codechef.stars}`,
-        `Highest: ${codechef.highestRating}`,
-        `Country Rank: ${codechef.countryRank}`,
+      accentColor: '#8b5cf6',
+      stats: [
+        { label: 'Rating', value: `${codechef.currentRating ?? 0} ${codechef.stars ?? ''}` },
+        { label: 'Highest Rating', value: String(codechef.highestRating ?? 0) },
+        { label: 'Global Rank', value: String(codechef.globalRank ?? 'N/A') },
       ]
     });
   }
 
   if (platforms.length === 0) return '';
 
-  const colWidth = Math.floor(width / platforms.length);
+  const cardGap = 16;
+  const cardWidth = Math.floor((width - (cardGap * (platforms.length - 1))) / platforms.length);
+  const cardHeight = 180;
 
-  const cols = platforms.map((p, i) => `
-    <g transform="translate(${i * colWidth}, 0)">
-      <text
-        font-family="'Segoe UI', sans-serif"
-        font-size="10"
-        font-weight="700"
-        fill="#58a6ff"
-        x="0" y="0"
-        letter-spacing="1">
-        ${p.title.toUpperCase()}
-      </text>
-      ${p.lines.map((line, j) => `
-        <text
-          font-family="'Segoe UI', sans-serif"
-          font-size="11"
-          fill="#c9d1d9"
-          x="0"
-          y="${16 + j * 16}">
-          ${line}
-        </text>
-      `).join('')}
-    </g>
-  `).join('');
+  const cards = platforms.map((p, i) =>
+    renderCPCard({
+      x: x + i * (cardWidth + cardGap),
+      y: y + 40,
+      width: cardWidth,
+      height: cardHeight,
+      title: p.title,
+      accentColor: p.accentColor,
+      stats: p.stats,
+    })
+  ).join('');
 
   return `
-    <g transform="translate(${x}, ${y})">
-      <text
-        font-family="'Segoe UI', sans-serif"
-        font-size="10"
-        font-weight="600"
-        fill="#8b949e"
-        x="0" y="0"
-        letter-spacing="2">
+    <g>
+      <text x="${x}" y="${y + 16}" 
+        font-family="'SF Pro Display', -apple-system, sans-serif" 
+        font-size="13" font-weight="600" fill="${colors.secondaryText}" 
+        letter-spacing="0.5">
         COMPETITIVE PROGRAMMING
       </text>
-      <line
-        x1="0" y1="8"
-        x2="${width}" y2="8"
-        stroke="#30363d"
-        stroke-width="0.5"/>
-      <g transform="translate(0, 20)">
-        ${cols}
-      </g>
-    </g>
-  `;
+      <line x1="${x}" y1="${y + 24}" x2="${x + width}" y2="${y + 24}" 
+        stroke="${colors.border}" stroke-width="0.5"/>
+      ${cards}
+    </g>`;
 }

--- a/src/renderers/svg.renderer.js
+++ b/src/renderers/svg.renderer.js
@@ -161,9 +161,10 @@ export function renderStatItem({ x, y, label, value, icon, accentColor, showProg
   // dynamic font size based on value length
   const valueStr = String(value);
   let fontSize = 32;
-  if (valueStr.length > 10) fontSize = 18;
-  else if (valueStr.length > 7) fontSize = 22;
-  else if (valueStr.length > 5) fontSize = 26;
+  if (valueStr.length > 8) fontSize = 14;
+  else if (valueStr.length > 6) fontSize = 18;
+  else if (valueStr.length > 4) fontSize = 24;
+  
 
   let iconElement = '';
   if (icon) {
@@ -186,7 +187,7 @@ export function renderStatItem({ x, y, label, value, icon, accentColor, showProg
   return `
   <g>
     ${iconElement}
-    <text x="${x}" y="${y}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="${fontSize}" font-weight="700" fill="${colors.primaryText}">${value}</text>
+    <text x="${x}" y="${y}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="${fontSize}" font-weight="700" fill="${colors.primaryText}" textLength="${valueStr.length > 10 ? '90' : ''}" lengthAdjust="${valueStr.length > 10 ? 'spacingAndGlyphs' : ''}">${value}</text>
     <text x="${x}" y="${y + 20}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">${label}</text>
     ${progressBar}
   </g>`;

--- a/src/renderers/svg.renderer.js
+++ b/src/renderers/svg.renderer.js
@@ -1,5 +1,21 @@
 // SVG Layout System
+// src/renderers/svg.renderer.js
 
+export function getColors() {
+  return {
+    background: '#0f172a',
+    cardBg: '#111827',
+    border: '#1f2937',
+
+    primaryText: '#f9fafb',
+    secondaryText: '#d1d5db',
+    mutedText: '#9ca3af',
+
+    success: '#22c55e',
+    warning: '#f59e0b',
+    danger: '#ef4444',
+  };
+}
 import darkTheme from '../themes/dark.theme.js';
 import lightTheme from '../themes/light.theme.js';
 import draculaTheme from '../themes/dracula.theme.js';

--- a/src/routes/profile.route.js
+++ b/src/routes/profile.route.js
@@ -14,6 +14,9 @@ import { renderContributionChart, generateFakeContributionData, renderDonutChart
 import { getGitHubUserData } from '../services/github.service.js';
 import { getContributionData } from '../services/github-graphql.service.js';
 import { getLeetCodeData } from '../services/leetcode.service.js';
+import { getCodeforcesData } from '../services/codeforces.service.js';
+import { getCodeChefData } from '../services/codechef.service.js';
+import { renderCPSection } from '../renderers/cp-section.renderer.js';
 import { logApiAccess } from '../utils/logger.js';
 
 const router = Router();
@@ -50,25 +53,21 @@ function getTopLanguages(repos, max = 5) {
   return sorted;
 }
 
-// GET /api/profile?username=SamXop123&theme=dark&leetcode=username (or leetcode=false to disable)
+// GET /api/profile?username=SamXop123&theme=dark&leetcode=username&codeforces=handle&codechef=handle
 router.get('/', async (req, res) => {
   // log API access
   logApiAccess(req).catch(err => console.error('Log failed:', err.message));
 
-  const { theme, leetcode, align, hide_trophies } = req.query;
+  const { theme, leetcode, align, hide_trophies, codeforces, codechef } = req.query;
 
-  // Sanitize and validate username before passing to GitHub API
-  // GitHub usernames: max 39 chars, alphanumeric and hyphens only, no leading/trailing hyphens
-  // Ensure it's a string (prevents Express array query parameter trickery)
+  // Sanitize and validate username
   const rawUsername = typeof req.query.username === 'string' ? req.query.username : '';
   const usernameRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$|^[a-zA-Z0-9]$/;
 
   let username;
   if (!rawUsername) {
-    // No username provided — use default
     username = DEFAULT_USERNAME;
   } else if (!usernameRegex.test(rawUsername)) {
-    // Invalid username — return friendly SVG error instead of crashing
     const errorSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="600" height="120">
       <rect width="600" height="120" rx="10" fill="#0d1117" />
       <text x="300" y="50" font-family="Arial" font-size="16" fill="#f87171" text-anchor="middle" font-weight="bold">
@@ -93,9 +92,7 @@ router.get('/', async (req, res) => {
   // check if LeetCode is explicitly disabled
   const leetcodeDisabled = leetcode === 'false';
   const shouldRenderLeetCode = Boolean(leetcode && !leetcodeDisabled);
-
   const showRepositoryStats = !shouldRenderLeetCode;
-
   const hideTrophies = hide_trophies === 'true';
 
   // alignment
@@ -104,41 +101,47 @@ router.get('/', async (req, res) => {
 
   // fetch github data
   const result = await getGitHubUserData(username);
-
   if (!result.success) {
     return res.status(500).json({ error: result.error });
   }
-
   const { data } = result;
 
   // fetch contribution data for streaks
   const contributionResult = await getContributionData(username);
   const contributionData = contributionResult.success ? contributionResult.data : null;
 
-  // fetch LC data if username provided and not disabled
-  const leetcodeResult = shouldRenderLeetCode ? await getLeetCodeData(leetcode) : null;
+  // fetch all platform data in parallel
+  const [leetcodeResult, codeforcesResult, codechefResult] = await Promise.all([
+    shouldRenderLeetCode ? getLeetCodeData(leetcode) : null,
+    codeforces ? getCodeforcesData(codeforces) : null,
+    codechef ? getCodeChefData(codechef) : null,
+  ]);
+
   const leetcodeData = leetcodeResult?.success ? leetcodeResult.data : null;
+  const codeforcesData = codeforcesResult?.success ? codeforcesResult.data : null;
+  const codechefData = codechefResult?.success ? codechefResult.data : null;
+
+  // count active CP platforms
+  const cpPlatforms = [
+    shouldRenderLeetCode ? leetcodeData : null,
+    codeforcesData,
+    codechefData,
+  ].filter(Boolean).length;
+
+  const showCPSection = cpPlatforms >= 2;
 
   const width = LAYOUT.width;
   const cardWidth = calculateCardWidth(3);
   const cardHeight = 140;
   const row1Y = 95;
 
-  // Row 2: contribution chart (left) + placeholder (right)
+  // Row 2
   const row2Y = row1Y + cardHeight + LAYOUT.cardGap;
   const chartWidth = calculateCardWidth(2) + LAYOUT.cardGap / 2;
   const row2CardWidth = calculateCardWidth(2) - LAYOUT.cardGap / 2;
   const row2Height = 200;
 
-  // Row 3: trophy row
-  const row3Y = row2Y + row2Height + LAYOUT.cardGap;
-  const row3Height = 165;
   const fullWidth = width - (LAYOUT.padding * 2);
-
-  // Dynamic height
-  const height = hideTrophies
-    ? row2Y + row2Height + LAYOUT.padding
-    : row3Y + row3Height + LAYOUT.padding;
 
   // Card 1: github activity
   const card1Title = 'GitHub Activity';
@@ -155,60 +158,72 @@ router.get('/', async (req, res) => {
     { label: 'Total', value: contributionData ? formatNumber(contributionData.totalContributionDays) : '-' },
   ];
 
-  // card 3: changes based on leetcode parameter
+// Card 3: adaptive based on CP platforms
   let card3Title;
   let card3Stats;
 
-  if (showRepositoryStats) {
+  if (!codeforcesData && !codechefData) {
+    if (showRepositoryStats) {
+      card3Title = 'Repository Stats';
+      card3Stats = [
+        { label: 'Repositories', value: formatNumber(data.publicRepos) },
+        { label: 'Stars', value: formatNumber(data.totalStars) },
+        { label: 'Followers', value: formatNumber(data.followers) },
+      ];
+    } else {
+      const getRatingOrRanking = () => {
+        if (!leetcodeData) return { label: 'Rating', value: '-' };
+        if (leetcodeData.contestRating) return { label: 'Rating', value: String(leetcodeData.contestRating) };
+        return { label: 'Rank', value: formatNumber(leetcodeData.ranking) };
+      };
+      const getEMHStats = () => {
+        if (!leetcodeData) return { label: 'E/M/H', value: '-', isVertical: false };
+        return { label: 'E/M/H', isVertical: true, easy: leetcodeData.easySolved, medium: leetcodeData.mediumSolved, hard: leetcodeData.hardSolved };
+      };
+      card3Title = leetcodeData ? 'LeetCode Stats' : 'Competitive Coding';
+      card3Stats = [
+        { label: 'Solved', value: leetcodeData ? formatNumber(leetcodeData.totalSolved) : '-' },
+        getEMHStats(),
+        getRatingOrRanking(),
+      ];
+    }
+  } else if (!showCPSection) {
+    if (codeforcesData) {
+      const rank = codeforcesData.rank ?? 'unrated';
+      const shortRank = rank.split(' ').map(w => w[0].toUpperCase() + w.slice(1, 3)).join('.');
+      card3Title = 'Codeforces Stats';
+      card3Stats = [
+        { label: 'Rating', value: String(codeforcesData.rating) },
+        { label: 'Rank', value: shortRank },
+        { label: 'Max Rating', value: String(codeforcesData.maxRating) },
+      ];
+    } else {
+      card3Title = 'CodeChef Stats';
+      card3Stats = [
+        { label: 'Rating', value: String(codechefData.currentRating) },
+        { label: 'Stars', value: codechefData.stars },
+        { label: 'Highest', value: String(codechefData.highestRating) },
+      ];
+    }
+  } else {
     card3Title = 'Repository Stats';
     card3Stats = [
       { label: 'Repositories', value: formatNumber(data.publicRepos) },
       { label: 'Stars', value: formatNumber(data.totalStars) },
       { label: 'Followers', value: formatNumber(data.followers) },
     ];
-  } else {
-    // when leetcode is enabled: show its stats
-    // use rating if available, otherwise fall back to ranking
-    const getRatingOrRanking = () => {
-      if (!leetcodeData) return { label: 'Rating', value: '-' };
-      if (leetcodeData.contestRating) {
-        return { label: 'Rating', value: String(leetcodeData.contestRating) };
-      }
-      return { label: 'Rank', value: formatNumber(leetcodeData.ranking) };
-    };
-
-    // E/M/H as vertical layout object
-    const getEMHStats = () => {
-      if (!leetcodeData) return { label: 'E/M/H', value: '-', isVertical: false };
-      return {
-        label: 'E/M/H',
-        isVertical: true,
-        easy: leetcodeData.easySolved,
-        medium: leetcodeData.mediumSolved,
-        hard: leetcodeData.hardSolved,
-      };
-    };
-
-    card3Title = leetcodeData ? 'LeetCode Stats' : 'Competitive Coding';
-    card3Stats = [
-      { label: 'Solved', value: leetcodeData ? formatNumber(leetcodeData.totalSolved) : '-' },
-      getEMHStats(),
-      getRatingOrRanking(),
-    ];
   }
 
-  // use real contribution data for chart (last 30 days)
+  // contribution chart data
   let chartData;
   if (contributionData && contributionData.days && contributionData.days.length > 0) {
-    // get last 30 days of real contribution data
     const recentDays = contributionData.days.slice(-30);
     chartData = recentDays.map(day => day.count);
   } else {
-    // fallback to fake data if real data unavailable
     chartData = generateFakeContributionData(30);
   }
 
-  // calculate top languages from repos
+  // top languages
   const topLanguages = getTopLanguages(data.repos, 5);
 
   // trophy data
@@ -223,15 +238,29 @@ router.get('/', async (req, res) => {
   };
 
   // build SVG content
+  // Row 3: CP section (before trophies), Row 4: trophies
+  const cpSectionHeight = showCPSection ? 120 : 0;
+  const cpRowY = row2Y + row2Height + LAYOUT.cardGap;
+  const trophyRowY = showCPSection
+    ? cpRowY + cpSectionHeight + LAYOUT.cardGap
+    : row2Y + row2Height + LAYOUT.cardGap;
+  const trophyRowHeight = 165;
+
+  const totalHeight = hideTrophies
+    ? showCPSection
+      ? cpRowY + cpSectionHeight + LAYOUT.padding
+      : row2Y + row2Height + LAYOUT.padding
+    : trophyRowY + trophyRowHeight + LAYOUT.padding;
+
   const content = [
-    renderBackground(width, height),
+    renderBackground(width, totalHeight),
     renderHeader({
       x: LAYOUT.padding,
       y: 52,
       title: `${data.name || username}'s Dashboard`,
       subtitle: data.bio ? (data.bio.length > 60 ? data.bio.slice(0, 60) + '...' : data.bio) : `@${username}`,
       avatarUrl: data.avatarDataUri || data.avatarUrl,
-      align: headerAlign
+      align: headerAlign,
     }),
 
     // Row 1: stat cards
@@ -239,23 +268,35 @@ router.get('/', async (req, res) => {
     renderCardWithStats({ x: calculateCardX(1, cardWidth), y: row1Y, width: cardWidth, height: cardHeight, title: 'Streak Stats', stats: streakStats }),
     renderCardWithStats({ x: calculateCardX(2, cardWidth), y: row1Y, width: cardWidth, height: cardHeight, title: card3Title, stats: card3Stats }),
 
-    // Row 2: contribution chart (left) + top languages donut (right)
+    // Row 2: contribution chart + top languages
     renderContributionChart({ x: LAYOUT.padding, y: row2Y, width: chartWidth, height: row2Height, title: 'Contribution Activity', data: chartData }),
     renderDonutChart({ x: LAYOUT.padding + chartWidth + LAYOUT.cardGap, y: row2Y, width: row2CardWidth, height: row2Height, title: 'Top Languages', data: topLanguages }),
 
-    // Row 3: trophy row
+    // Row 3: CP section (only when 2+ platforms)
+    showCPSection
+      ? renderCPSection({
+          x: LAYOUT.padding,
+          y: cpRowY,
+          width: fullWidth,
+          leetcode: shouldRenderLeetCode ? leetcodeData : null,
+          codeforces: codeforcesData,
+          codechef: codechefData,
+        })
+      : '',
+
+    // Row 4: trophy row
     hideTrophies
       ? ''
       : renderTrophyRow({
           x: LAYOUT.padding,
-          y: row3Y,
+          y: trophyRowY,
           width: fullWidth,
-          height: row3Height,
-          data: trophyData
+          height: trophyRowHeight,
+          data: trophyData,
         }),
   ].join('\n');
 
-  const svg = wrapSvg(content, width, height);
+  const svg = wrapSvg(content, width, totalHeight);
 
   res.setHeader('Content-Type', 'image/svg+xml');
   res.setHeader('Cache-Control', 'public, max-age=1800');

--- a/src/routes/profile.route.js
+++ b/src/routes/profile.route.js
@@ -21,46 +21,45 @@ import { logApiAccess } from '../utils/logger.js';
 
 const router = Router();
 
-// default fallback username
 const DEFAULT_USERNAME = process.env.DEFAULT_USERNAME || 'SamXop123';
 
-// to format large numbers (e.g. 1500 -> 1.5k)
+const CF_RANK_MAP = {
+  'newbie': 'Newbie',
+  'pupil': 'Pupil',
+  'specialist': 'Specialist',
+  'expert': 'Expert',
+  'candidate master': 'Cand.M',
+  'master': 'Master',
+  'international master': 'Int.M',
+  'grandmaster': 'GM',
+  'international grandmaster': 'Int.GM',
+  'legendary grandmaster': 'Leg.GM',
+};
+
 function formatNumber(num) {
-  if (num >= 1000000) {
-    return (num / 1000000).toFixed(1) + 'M';
-  }
-  if (num >= 1000) {
-    return (num / 1000).toFixed(1) + 'k';
-  }
+  if (num >= 1000000) return (num / 1000000).toFixed(1) + 'M';
+  if (num >= 1000) return (num / 1000).toFixed(1) + 'k';
   return num.toString();
 }
 
-// calculate top languages from repos
 function getTopLanguages(repos, max = 5) {
   const langCounts = {};
-
   repos.forEach((repo) => {
     if (repo.language) {
       langCounts[repo.language] = (langCounts[repo.language] || 0) + 1;
     }
   });
-
-  const sorted = Object.entries(langCounts)
+  return Object.entries(langCounts)
     .map(([label, value]) => ({ label, value }))
     .sort((a, b) => b.value - a.value)
     .slice(0, max);
-
-  return sorted;
 }
 
-// GET /api/profile?username=SamXop123&theme=dark&leetcode=username&codeforces=handle&codechef=handle
 router.get('/', async (req, res) => {
-  // log API access
   logApiAccess(req).catch(err => console.error('Log failed:', err.message));
 
   const { theme, leetcode, align, hide_trophies, codeforces, codechef } = req.query;
 
-  // Sanitize and validate username
   const rawUsername = typeof req.query.username === 'string' ? req.query.username : '';
   const usernameRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$|^[a-zA-Z0-9]$/;
 
@@ -86,31 +85,25 @@ router.get('/', async (req, res) => {
     username = rawUsername;
   }
 
-  // theme (default is dark)
   setTheme(theme || 'dark');
 
-  // check if LeetCode is explicitly disabled
   const leetcodeDisabled = leetcode === 'false';
   const shouldRenderLeetCode = Boolean(leetcode && !leetcodeDisabled);
   const showRepositoryStats = !shouldRenderLeetCode;
   const hideTrophies = hide_trophies === 'true';
 
-  // alignment
   const validAlignments = ['left', 'center', 'right'];
   const headerAlign = validAlignments.includes(align) ? align : 'left';
 
-  // fetch github data
   const result = await getGitHubUserData(username);
   if (!result.success) {
     return res.status(500).json({ error: result.error });
   }
   const { data } = result;
 
-  // fetch contribution data for streaks
   const contributionResult = await getContributionData(username);
   const contributionData = contributionResult.success ? contributionResult.data : null;
 
-  // fetch all platform data in parallel
   const [leetcodeResult, codeforcesResult, codechefResult] = await Promise.all([
     shouldRenderLeetCode ? getLeetCodeData(leetcode) : null,
     codeforces ? getCodeforcesData(codeforces) : null,
@@ -121,7 +114,6 @@ router.get('/', async (req, res) => {
   const codeforcesData = codeforcesResult?.success ? codeforcesResult.data : null;
   const codechefData = codechefResult?.success ? codechefResult.data : null;
 
-  // count active CP platforms
   const cpPlatforms = [
     shouldRenderLeetCode ? leetcodeData : null,
     codeforcesData,
@@ -135,7 +127,6 @@ router.get('/', async (req, res) => {
   const cardHeight = 140;
   const row1Y = 95;
 
-  // Row 2
   const row2Y = row1Y + cardHeight + LAYOUT.cardGap;
   const chartWidth = calculateCardWidth(2) + LAYOUT.cardGap / 2;
   const row2CardWidth = calculateCardWidth(2) - LAYOUT.cardGap / 2;
@@ -143,7 +134,6 @@ router.get('/', async (req, res) => {
 
   const fullWidth = width - (LAYOUT.padding * 2);
 
-  // Card 1: github activity
   const card1Title = 'GitHub Activity';
   const card1Stats = [
     { label: 'Contributions', value: contributionData ? formatNumber(contributionData.totalContributions) : '-' },
@@ -151,14 +141,12 @@ router.get('/', async (req, res) => {
     { label: 'Issues Opened', value: contributionData ? formatNumber(contributionData.totalIssues) : '-' },
   ];
 
-  // Card 2: streak stats
   const streakStats = [
     { label: 'Current', value: contributionData ? formatNumber(contributionData.currentStreak) : '-' },
     { label: 'Longest', value: contributionData ? formatNumber(contributionData.longestStreak) : '-' },
     { label: 'Total', value: contributionData ? formatNumber(contributionData.totalContributionDays) : '-' },
   ];
 
-// Card 3: adaptive based on CP platforms
   let card3Title;
   let card3Stats;
 
@@ -178,7 +166,13 @@ router.get('/', async (req, res) => {
       };
       const getEMHStats = () => {
         if (!leetcodeData) return { label: 'E/M/H', value: '-', isVertical: false };
-        return { label: 'E/M/H', isVertical: true, easy: leetcodeData.easySolved, medium: leetcodeData.mediumSolved, hard: leetcodeData.hardSolved };
+        return {
+          label: 'E/M/H',
+          isVertical: true,
+          easy: leetcodeData.easySolved,
+          medium: leetcodeData.mediumSolved,
+          hard: leetcodeData.hardSolved,
+        };
       };
       card3Title = leetcodeData ? 'LeetCode Stats' : 'Competitive Coding';
       card3Stats = [
@@ -189,12 +183,11 @@ router.get('/', async (req, res) => {
     }
   } else if (!showCPSection) {
     if (codeforcesData) {
-      const rank = codeforcesData.rank ?? 'unrated';
-      const shortRank = rank.split(' ').map(w => w[0].toUpperCase() + w.slice(1, 3)).join('.');
+      const rankShort = CF_RANK_MAP[codeforcesData.rank?.toLowerCase()] ?? codeforcesData.rank ?? 'unrated';
       card3Title = 'Codeforces Stats';
       card3Stats = [
         { label: 'Rating', value: String(codeforcesData.rating) },
-        { label: 'Rank', value: shortRank },
+        { label: 'Rank', value: rankShort },
         { label: 'Max Rating', value: String(codeforcesData.maxRating) },
       ];
     } else {
@@ -214,7 +207,6 @@ router.get('/', async (req, res) => {
     ];
   }
 
-  // contribution chart data
   let chartData;
   if (contributionData && contributionData.days && contributionData.days.length > 0) {
     const recentDays = contributionData.days.slice(-30);
@@ -223,10 +215,8 @@ router.get('/', async (req, res) => {
     chartData = generateFakeContributionData(30);
   }
 
-  // top languages
   const topLanguages = getTopLanguages(data.repos, 5);
 
-  // trophy data
   const trophyData = {
     commits: contributionData?.totalContributions || 0,
     prs: contributionData?.totalPRs || 0,
@@ -237,9 +227,7 @@ router.get('/', async (req, res) => {
     reviews: contributionData?.totalReviews || 0,
   };
 
-  // build SVG content
-  // Row 3: CP section (before trophies), Row 4: trophies
-  const cpSectionHeight = showCPSection ? 240 : 0;
+  const cpSectionHeight = showCPSection ? 156 : 0;
   const cpRowY = row2Y + row2Height + LAYOUT.cardGap;
   const trophyRowY = showCPSection
     ? cpRowY + cpSectionHeight + LAYOUT.cardGap
@@ -263,16 +251,13 @@ router.get('/', async (req, res) => {
       align: headerAlign,
     }),
 
-    // Row 1: stat cards
     renderCardWithStats({ x: calculateCardX(0, cardWidth), y: row1Y, width: cardWidth, height: cardHeight, title: card1Title, stats: card1Stats }),
     renderCardWithStats({ x: calculateCardX(1, cardWidth), y: row1Y, width: cardWidth, height: cardHeight, title: 'Streak Stats', stats: streakStats }),
     renderCardWithStats({ x: calculateCardX(2, cardWidth), y: row1Y, width: cardWidth, height: cardHeight, title: card3Title, stats: card3Stats }),
 
-    // Row 2: contribution chart + top languages
     renderContributionChart({ x: LAYOUT.padding, y: row2Y, width: chartWidth, height: row2Height, title: 'Contribution Activity', data: chartData }),
     renderDonutChart({ x: LAYOUT.padding + chartWidth + LAYOUT.cardGap, y: row2Y, width: row2CardWidth, height: row2Height, title: 'Top Languages', data: topLanguages }),
 
-    // Row 3: CP section (only when 2+ platforms)
     showCPSection
       ? renderCPSection({
           x: LAYOUT.padding,
@@ -284,7 +269,6 @@ router.get('/', async (req, res) => {
         })
       : '',
 
-    // Row 4: trophy row
     hideTrophies
       ? ''
       : renderTrophyRow({

--- a/src/routes/profile.route.js
+++ b/src/routes/profile.route.js
@@ -239,7 +239,7 @@ router.get('/', async (req, res) => {
 
   // build SVG content
   // Row 3: CP section (before trophies), Row 4: trophies
-  const cpSectionHeight = showCPSection ? 120 : 0;
+  const cpSectionHeight = showCPSection ? 240 : 0;
   const cpRowY = row2Y + row2Height + LAYOUT.cardGap;
   const trophyRowY = showCPSection
     ? cpRowY + cpSectionHeight + LAYOUT.cardGap

--- a/src/services/codechef.service.js
+++ b/src/services/codechef.service.js
@@ -1,0 +1,25 @@
+export async function getCodeChefData(handle) {
+  try {
+    const res = await fetch(
+      `https://codechef-api.vercel.app/handle/${handle}`
+    );
+    const data = await res.json();
+
+    if (!data || data.success === false) {
+      return { success: false, error: 'User not found' };
+    }
+
+    return {
+      success: true,
+      data: {
+        handle: data.name ?? handle,
+        currentRating: data.currentRating ?? 0,
+        highestRating: data.highestRating ?? 0,
+        stars: data.stars ?? '1★',
+        countryRank: data.countryRank ?? 'N/A',
+      }
+    };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+}

--- a/src/services/codechef.service.js
+++ b/src/services/codechef.service.js
@@ -1,22 +1,21 @@
 export async function getCodeChefData(handle) {
   try {
     const res = await fetch(
-      `https://codechef-api.vercel.app/handle/${handle}`
+      `https://competeapi.vercel.app/user/codechef/${handle}/`
     );
     const data = await res.json();
 
-    if (!data || data.success === false) {
+    if (!data || !data.username) {
       return { success: false, error: 'User not found' };
     }
 
     return {
       success: true,
       data: {
-        handle: data.name ?? handle,
-        currentRating: data.currentRating ?? 0,
-        highestRating: data.highestRating ?? 0,
-        stars: data.stars ?? '1★',
-        countryRank: data.countryRank ?? 'N/A',
+        handle: data.username ?? handle,
+        currentRating: data.rating_number ?? 0,
+        highestRating: data.max_rank ?? data.rating_number ?? 0,
+        stars: data.rating ?? '1★',
       }
     };
   } catch (err) {

--- a/src/services/codeforces.service.js
+++ b/src/services/codeforces.service.js
@@ -1,0 +1,26 @@
+export async function getCodeforcesData(handle) {
+  try {
+    const res = await fetch(
+      `https://codeforces.com/api/user.info?handles=${handle}`
+    );
+    const data = await res.json();
+
+    if (data.status !== 'OK') {
+      return { success: false, error: 'User not found' };
+    }
+
+    const user = data.result[0];
+    return {
+      success: true,
+      data: {
+        handle: user.handle,
+        rating: user.rating ?? 0,
+        maxRating: user.maxRating ?? 0,
+        rank: user.rank ?? 'unrated',
+        maxRank: user.maxRank ?? 'unrated',
+      }
+    };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+}


### PR DESCRIPTION
## Summary
Closes #10

Implements adaptive Codeforces and CodeChef stats based on maintainer's approved layout architecture.

## New Files
- `src/services/codeforces.service.js` — Codeforces API integration
- `src/services/codechef.service.js` — CodeChef API integration
- `src/renderers/cp-section.renderer.js` — adaptive CP section renderer

## Modified Files
- `src/routes/profile.route.js` — adaptive card 3 + CP section logic
- `src/renderers/svg.renderer.js` — fix text overflow for long rank strings

## Adaptive Layout Behavior
- Single CP platform → reuses card 3 position
- Multiple platforms → dedicated CP section rendered above trophies
- No CP platforms → existing repo stats fallback unchanged

## New Query Parameters
| Parameter | Example |
|-----------|---------|
| codeforces | `&codeforces=tourist` |
| codechef | `&codechef=gennady` |

## Checklist
- [x] Tested locally
- [x] Single CF platform works
- [x] Single CC platform works
- [x] CF + CC together shows CP section
- [x] All 3 platforms work
- [x] Base behavior unchanged