### PR TITLE
Add hover effect to main nav bar

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -127,7 +127,14 @@ section{
 .navbtn a{
   text-decoration: none;
   cursor: pointer;
-  color: inherit;
+  color: var(--text-secondary);
+  transition: color var(--transition-base), transform var(--transition-base);
+}
+
+.navbtn a:hover,
+.navbtn a:focus-visible{
+  color: var(--accent-purple);
+  transform: translateY(-1px);
 }
 .navlogo{
   padding-left: 50px;


### PR DESCRIPTION
This update makes the main navbar links behave the same way as the footer links so the site feels more consistent and polished. The navbar links now use the secondary text color by default, then on hover or keyboard focus they smoothly change to the purple accent color and move up slightly by 1px, which gives a cleaner interactive feel and also improves accessibility for keyboard users because focus now gets the same visual feedback as hover.