### PR TITLE
feat: add responsive hamburger menu for mobile navbar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,23 +18,32 @@
 
 <body>
   <!-- NAVBAR -->
-    <div class="navbar">
-      <div class="navlogo">
-        <a href="https://samdev-pulse.vercel.app/">
-          <img src="./logo-samdev-pulse.png" alt="logo-samdev-pulse">
-        </a>
-      </div>
-      <div class="navbtn">
-        <ul>
-          <li><a href="#home">HOME</a></li>
-          <li><a href="#features">FEATURES</a></li>
-          <li><a href="#themes">THEMES</a></li>
-          <li><a href="#preview">TRY IT LIVE</a></li>
-          <li><a href="#guide">GUIDE</a></li>
-          <li><a href="#about">ABOUT</a></li>
-        </ul>
-      </div>
+  <div class="navbar">
+    <div class="navlogo">
+      <a href="https://samdev-pulse.vercel.app/">
+        <img src="./logo-samdev-pulse.png" alt="logo-samdev-pulse">
+      </a>
     </div>
+
+    <!-- Hamburger button (visible on mobile only) -->
+    <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="nav-menu">
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>
+
+    <div class="navbtn" id="nav-menu">
+      <ul>
+        <li><a href="#home">HOME</a></li>
+        <li><a href="#features">FEATURES</a></li>
+        <li><a href="#themes">THEMES</a></li>
+        <li><a href="#preview">TRY IT LIVE</a></li>
+        <li><a href="#guide">GUIDE</a></li>
+        <li><a href="#about">ABOUT</a></li>
+      </ul>
+    </div>
+  </div>
+
   <!-- Hero Section -->
   <section class="hero" id="home">
     <div class="hero-background"></div>
@@ -349,7 +358,7 @@
             <p class="theme-desc">All natural pine, faux fur and a bit of soho vibes</p>
           </div>
         </div>
-        
+
         <div class="theme-card" data-theme="aurora">
           <div class="theme-preview aurora-theme">
             <div class="theme-swatch-group">
@@ -363,7 +372,7 @@
             <p class="theme-desc">Cool cyan and emerald lights over deep blue night</p>
           </div>
         </div>
-        
+
         <div class="theme-card" data-theme="midnight-sunset">
           <div class="theme-preview midnight-sunset-theme">
             <div class="theme-swatch-group">

--- a/public/script.js
+++ b/public/script.js
@@ -221,3 +221,55 @@
     init();
   }
 })();
+
+// Hamburger Menu
+(function () {
+  'use strict';
+
+  function initHamburger() {
+    const hamburger = document.getElementById('nav-hamburger');
+    const navMenu   = document.getElementById('nav-menu');
+
+    if (!hamburger || !navMenu) return;
+
+    // Toggle open/close
+    hamburger.addEventListener('click', function () {
+      const isOpen = navMenu.classList.toggle('is-open');
+      hamburger.classList.toggle('is-open', isOpen);
+      hamburger.setAttribute('aria-expanded', String(isOpen));
+    });
+
+    // Close menu when any nav link is clicked (smooth-scroll already handles the jump)
+    navMenu.querySelectorAll('a').forEach(function (link) {
+      link.addEventListener('click', function () {
+        navMenu.classList.remove('is-open');
+        hamburger.classList.remove('is-open');
+        hamburger.setAttribute('aria-expanded', 'false');
+      });
+    });
+
+    // Close menu on outside click
+    document.addEventListener('click', function (e) {
+      if (!hamburger.contains(e.target) && !navMenu.contains(e.target)) {
+        navMenu.classList.remove('is-open');
+        hamburger.classList.remove('is-open');
+        hamburger.setAttribute('aria-expanded', 'false');
+      }
+    });
+
+    // Close menu on Escape key
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        navMenu.classList.remove('is-open');
+        hamburger.classList.remove('is-open');
+        hamburger.setAttribute('aria-expanded', 'false');
+      }
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initHamburger);
+  } else {
+    initHamburger();
+  }
+})();

--- a/public/styles.css
+++ b/public/styles.css
@@ -146,8 +146,128 @@ section{
   padding-right: 100px;
 }
 
+/* ===== Hamburger Button ===== */
+.nav-hamburger {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 5px;
+  width: 44px;
+  height: 44px;
+  padding: 8px;
+  margin-right: 16px;
+  background: transparent;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: all var(--transition-base);
+  flex-shrink: 0;
+}
 
+.nav-hamburger:hover {
+  border-color: var(--accent-purple);
+  background: var(--surface-glass);
+}
 
+.nav-hamburger span {
+  display: block;
+  width: 20px;
+  height: 2px;
+  background: var(--text-secondary);
+  border-radius: 2px;
+  transition: all var(--transition-base);
+  transform-origin: center;
+}
+
+/* Animate to X when open */
+.nav-hamburger.is-open span:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+  background: var(--accent-purple);
+}
+.nav-hamburger.is-open span:nth-child(2) {
+  opacity: 0;
+  transform: scaleX(0);
+}
+.nav-hamburger.is-open span:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
+  background: var(--accent-purple);
+}
+
+/* ===== Responsive Navbar ===== */
+@media (max-width: 900px) {
+  .navlogo {
+    padding-left: 20px;
+  }
+
+  .navbtn {
+    padding-right: 0;
+  }
+
+  .navbtn ul {
+    gap: 32px;
+    padding: 16px 24px;
+    font-size: 0.85rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .nav-hamburger {
+    display: flex;
+  }
+
+  .navbtn {
+    /* Hidden by default on mobile — drops down from navbar */
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: rgba(8, 8, 23, 0.97);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
+
+    /* Slide animation */
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.35s cubic-bezier(0.4, 0, 0.2, 1),
+                opacity 0.25s ease;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .navbtn.is-open {
+    max-height: 400px;
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .navbtn ul {
+    flex-direction: column;
+    gap: 0;
+    padding: 8px 0 16px;
+  }
+
+  .navbtn ul li a {
+    display: block;
+    padding: 12px 28px;
+    font-size: 0.9375rem;
+    letter-spacing: 0.06em;
+    border-left: 2px solid transparent;
+    transition: color var(--transition-base),
+                border-color var(--transition-base),
+                background var(--transition-base);
+  }
+
+  .navbtn ul li a:hover,
+  .navbtn ul li a:focus-visible {
+    color: var(--accent-purple);
+    border-left-color: var(--accent-purple);
+    background: rgba(139, 92, 246, 0.06);
+    transform: none; /* override the desktop lift effect */
+  }
+}
 /* ===== Hero Section ===== */
 .hero {
   position: relative;


### PR DESCRIPTION
The navbar was overflowing on smaller screens, so I added a hamburger menu that drops down on mobile.

Closes #28

## Changes
- `index.html` - hamburger button added between logo and nav links
- `styles.css` - button styles, 3-bar → X animation, slide-down dropdown, left-border accent on links
- `script.js` - toggles open/close, closes on link click / outside click / Escape, keeps `aria-expanded` in sync

## Breakpoints
- `≤ 900px` - tightens gap between nav links
- `≤ 768px` - hamburger kicks in, links collapse into dropdown