### PR TITLE
fix: resolve mobile overflow and element stretching issues on narrow viewports

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1299,6 +1299,7 @@ td code {
     font-size: 0.9rem;
     word-break: break-word;
     white-space: pre-wrap;
+    overflow-x: auto;
   }
 
   .footer-content {

--- a/public/styles.css
+++ b/public/styles.css
@@ -957,10 +957,11 @@ section {
   border-radius: var(--radius-lg);
   padding: var(--spacing-2xl);
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .params-table table {
-  min-width: unset;
+  min-width: 500px;
   width: 100%;
   margin-top: 15px;
 }
@@ -1104,8 +1105,9 @@ td code {
 }
 
 @media (max-width: 768px) {
-  .profile-avatar {
-    max-width: 280px;
+.profile-avatar {
+    max-width: 240px;
+    width: 80%;     
     margin: 0 auto;
   }
 }
@@ -1302,10 +1304,11 @@ td code {
     font-size: 1.1rem;
   }
 
-  .usage-card .code-block {
+.usage-card .code-block {
     font-size: 0.9rem;
-    word-break: break-word;
     white-space: pre-wrap;
+    word-break: break-all;
+    overflow-wrap: anywhere; 
     overflow-x: auto;
   }
 
@@ -1327,10 +1330,18 @@ td code {
 @media (max-width: 480px) {
   .hero-cta .btn,
   .cta-buttons .btn {
-  width: 100%;
-  justify-content: center;
-}
+    width: 100%;
+    justify-content: center;
+  }
 
+  .copy-btn, 
+  .preview-update-row .btn {
+    width: auto !important;
+    display: inline-flex;
+  }
+  .preview-update-row {
+    justify-content: center;
+  }
   .preview-panel {
     padding: var(--spacing-lg);
   }

--- a/public/styles.css
+++ b/public/styles.css
@@ -960,7 +960,8 @@ section {
 }
 
 .params-table table {
-  min-width: 720px;
+  min-width: unset;
+  width: 100%;
   margin-top: 15px;
 }
 
@@ -1313,10 +1314,6 @@ td code {
     padding: var(--spacing-sm);
   }
 
-
-  .params-table table {
-    min-width: 520px;
-  }
 }
 
 @media (max-width: 480px) {
@@ -1335,10 +1332,6 @@ td code {
 
   .params-title {
     font-size: 1.25rem;
-  }
-
-  .params-table table {
-    min-width: 460px;
   }
 }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -1103,6 +1103,13 @@ td code {
   display: block;
 }
 
+@media (max-width: 768px) {
+  .profile-avatar {
+    max-width: 280px;
+    margin: 0 auto;
+  }
+}
+
 /* ===== CTA Section ===== */
 .cta-section {
   background: var(--bg-primary);

--- a/public/styles.css
+++ b/public/styles.css
@@ -1317,10 +1317,11 @@ td code {
 }
 
 @media (max-width: 480px) {
-  .btn {
-    width: 100%;
-    justify-content: center;
-  }
+  .hero-cta .btn,
+  .cta-buttons .btn {
+  width: 100%;
+  justify-content: center;
+}
 
   .preview-panel {
     padding: var(--spacing-lg);


### PR DESCRIPTION
## Description
This PR resolves several mobile responsiveness issues identified during testing on narrow viewports (≤480px and ≤360px). Previously, elements like the parameters table, utility buttons, code blocks, and the developer profile avatar would overflow horizontally or stretch out of proportion, breaking the mobile layout.

## Fixes Issue
Closes #33 

## Changes Made
Specifically, the following adjustments were made in `styles.css`:
1. **Params Table Overflow:** Added `min-width: 500px` to the table and `-webkit-overflow-scrolling: touch` to the wrapper to ensure smooth horizontal scrolling on tiny screens without breaking the page width.
2. **Utility Buttons Stretching:** Targeted `.copy-btn` and `.preview-update-row .btn` with `width: auto !important` inside the 480px media query so they no longer stretch to 100% width.
3. **Avatar Sizing:** Added `max-width: 240px` and `width: 80%` to the `.profile-avatar` at the 768px breakpoint to prevent it from stretching edge-to-edge on small phones.
4. **Code Block Wrapping:** Applied `word-break: break-all` and `overflow-wrap: anywhere` to `.usage-card .code-block` to force long URLs and unbroken strings to wrap correctly on devices ≤375px.

## Steps to Test
1. Open the site in a browser and open DevTools.
2. Switch to a mobile viewport like **360x800 (Galaxy S8)**.
3. Verify that the **Params table** now scrolls horizontally.
4. Verify that the **Copy** and **Update Preview** buttons retain their intrinsic sizes.
5. Verify that the **Developer avatar** is cleanly sized and centered.
6. Verify that long URLs in the **Quick Start Guide** wrap neatly onto the next line.

### Visual Changes (Before & After)

<details>
<summary><b>Click to expand screenshots (5 pairs)</b></summary>
<br>

| Area / Section |  Before |  After |
| --- | --- | --- |
| **1. Table** | <img width="770" height="756" alt="Screenshot 2026-05-19 at 7 33 48 PM" src="https://github.com/user-attachments/assets/5318196c-b03b-4bbd-aaa8-7ca2f44235ac" /> | <img width="777" height="761" alt="Screenshot 2026-05-19 at 7 34 07 PM" src="https://github.com/user-attachments/assets/e5b2dd0f-7bb8-4aeb-abbc-49163419967e" /> |
| **2. Utility Buttons Stretching** | <img width="763" height="690" alt="Screenshot 2026-05-19 at 7 37 46 PM" src="https://github.com/user-attachments/assets/969f9807-9b6e-4e2f-a211-bfd03dae915b" /> | <img width="836" height="713" alt="Screenshot 2026-05-19 at 7 37 56 PM" src="https://github.com/user-attachments/assets/3dc29ddc-3ea0-4bda-8057-191c69c5fcdb" /> |
| **3. Code Block Wrapping** | <img width="799" height="747" alt="Screenshot 2026-05-19 at 7 39 29 PM" src="https://github.com/user-attachments/assets/218594cf-d6eb-4d99-b1f4-81b2ecc5e823" /> | <img width="805" height="765" alt="Screenshot 2026-05-19 at 7 39 35 PM" src="https://github.com/user-attachments/assets/8294ae6e-b563-4d52-a5c1-b9dcaa0f98ff" /> |
| **4. Avatar Sizing** | <img width="830" height="770" alt="Screenshot 2026-05-19 at 7 43 45 PM" src="https://github.com/user-attachments/assets/836fc4de-374a-42ae-941e-0f323c47a177" /> | <img width="831" height="761" alt="Screenshot 2026-05-19 at 7 43 51 PM" src="https://github.com/user-attachments/assets/4ca8d357-be1a-47a2-870c-23398ef7fbc7" /> |
| **5. Params Table Text** | <img width="783" height="759" alt="Screenshot 2026-05-19 at 7 42 58 PM" src="https://github.com/user-attachments/assets/448a2730-c812-46aa-a1fe-2113e5de2079" />| <img width="833" height="756" alt="Screenshot 2026-05-19 at 7 42 50 PM" src="https://github.com/user-attachments/assets/ee4107b2-0e83-47aa-9835-35c9a733dec4" /> |
</details>