### PR TITLE
add multiple dashboard themes and live preview support new dashboard themes add

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,11 @@
 # GitHub Personal Access Token (Required)
 # Generate at: https://github.com/settings/tokens (use classic token)
 # Scopes needed: public_repo, read:user
-GITHUB_TOKEN=your_github_personal_access_token_here
+GITHUB_TOKEN=your_github_personal_access_token
 
 # Default username when none provided (Optional)
 DEFAULT_USERNAME=SamXop123
+
 
 # Server port (Optional, default: 3000)
 PORT=3000

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-
 # 🚀 samdev-pulse
 
-> A calm, modern GitHub profile dashboard — generated as a single SVG.  
->  
+> A calm, modern GitHub profile dashboard — generated as a single SVG.
+>
 > Drop one image into your README and get live GitHub stats, contribution activity, language breakdowns, and achievement trophies. No widgets. No clutter. It just works.
 
 ---
@@ -13,8 +12,9 @@ Add this to your **GitHub profile README** :
 
 ```md
 ![samdev-pulse](https://samdev-pulse.vercel.app/api/profile?username=YOUR_GITHUB_USERNAME)
-````
-`YOUR_GITHUB_USERNAME` : change this to your github username. <br>
+```
+
+`YOUR_GITHUB_USERNAME` : change this to your GitHub username.
 That’s it. Your profile now renders a live dashboard.
 
 ### Live Example Preview
@@ -23,43 +23,64 @@ That’s it. Your profile now renders a live dashboard.
 
 ---
 
-## 🎨 Customization Examples
+# 🎨 Customization Examples
 
-### Theme
+## Theme
 
 ```md
 ![samdev-pulse](https://samdev-pulse.vercel.app/api/profile?username=YOUR_GITHUB_USERNAME&theme=tokyonight)
 ```
 
-Available themes:
-`dark` (default), `light`, `dracula`, `nord`, `tokyonight`, `monokai`, `gruvbox`, `solarized`, `catppuccin`, `rose-pine`, `aurora`, `midnight-sunset`
+### Available Themes
+
+`dark` (default), `light`, `dracula`, `nord`, `tokyonight`, `monokai`, `gruvbox`, `solarized`, `catppuccin`, `rose-pine`, `aurora`, `midnight-sunset`, `onedarkpro`, `material`, `synthwave84`, `forestnight`, `oceanicnext`, `emberglow`, `midnightneon`, `pasteldream`
 
 ---
 
-### Competitive Programming Stats (Optional)
+## ✨ Newly Added Themes
+
+| Theme         | Description                             |
+| ------------- | --------------------------------------- |
+| One Dark Pro  | VS Code inspired modern editor palette  |
+| Material      | Material UI inspired clean modern tones |
+| Synthwave 84  | Retro neon cyberpunk aesthetics         |
+| Forest Night  | Deep green nature-inspired palette      |
+| Oceanic Next  | Cool ocean blues with coding vibes      |
+| Ember Glow    | Warm fiery orange and crimson tones     |
+| Midnight Neon | Futuristic glowing cyber aesthetics     |
+| Pastel Dream  | Soft dreamy pastel gradients and tones  |
+
+---
+
+## 💻 Competitive Programming Stats (Optional)
 
 ```md
 ![samdev-pulse](https://samdev-pulse.vercel.app/api/profile?username=YOUR_GITHUB_USERNAME&leetcode=YOUR_LEETCODE_USERNAME&codeforces=YOUR_CODEFORCES_USERNAME&codechef=YOUR_CODECHEF_USERNAME)
 ```
 
 Depending on how many platforms you provide:
-- **1 platform:** Replaces the default repository stats card.
-- **2+ platforms:** Renders a dedicated "Competitive Programming" section at the bottom for a clean layout.
-- **0 platforms:** Shows the default repository stats card.
+
+* **1 platform:** Replaces the default repository stats card.
+* **2+ platforms:** Renders a dedicated "Competitive Programming" section at the bottom for a clean layout.
+* **0 platforms:** Shows the default repository stats card.
 
 ---
 
-### Header Alignment
+## 📍 Header Alignment
 
 ```md
 ![samdev-pulse](https://samdev-pulse.vercel.app/api/profile?username=YOUR_GITHUB_USERNAME&align=center)
 ```
 
-Options: `left` (default), `center`, `right`
+Options:
+
+* `left` (default)
+* `center`
+* `right`
 
 ---
 
-### Hide Trophies (Optional)
+## 🏆 Hide Trophies (Optional)
 
 ```md
 ![samdev-pulse](https://samdev-pulse.vercel.app/api/profile?username=YOUR_GITHUB_USERNAME&hide_trophies=true)
@@ -67,19 +88,19 @@ Options: `left` (default), `center`, `right`
 
 ---
 
-### Full Example
+## 🌟 Full Example
 
 ```md
-![samdev-pulse](https://samdev-pulse.vercel.app/api/profile?username=SamXop123&theme=tokyonight&align=center&leetcode=fjzzq2002&codeforces=tourist&codechef=tourist)
+![samdev-pulse](https://samdev-pulse.vercel.app/api/profile?username=SamXop123&theme=synthwave84&align=center&leetcode=fjzzq2002&codeforces=tourist&codechef=tourist)
 ```
 
-**Preview:**
+### Preview
 
-![samdev-pulse full preview](https://samdev-pulse.vercel.app/api/profile?username=SamXop123&theme=tokyonight&align=center&leetcode=fjzzq2002&codeforces=tourist&codechef=tourist)
+![samdev-pulse full preview](https://samdev-pulse.vercel.app/api/profile?username=SamXop123\&theme=synthwave84\&align=center\&leetcode=fjzzq2002\&codeforces=tourist\&codechef=tourist)
 
 ---
 
-## Why samdev-pulse?
+# ❓ Why samdev-pulse?
 
 * Designed as **one cohesive SVG**, not stitched widgets
 * Calm, readable visuals that don’t overpower your profile
@@ -87,44 +108,61 @@ Options: `left` (default), `center`, `right`
 
 ---
 
-## ✨ Features
+# ✨ Features
 
-### 📊 GitHub Activity
+## 📊 GitHub Activity
 
 * Total contributions (year)
 * Pull requests opened
 * Issues opened
 * Live data via GitHub REST API
 
-### 🔥 Streak Statistics
+---
+
+## 🔥 Streak Statistics
 
 * Current streak
 * Longest streak
 * Total contribution days
 * Powered by GitHub GraphQL API
 
-### 📈 Contribution Activity Graph
+---
+
+## 📈 Contribution Activity Graph
 
 * SVG line chart (last 30 days)
 * Auto-scaled Y-axis
 * Smooth curves with gradient fill
 
-### 🍩 Top Languages
+---
+
+## 🍩 Top Languages
 
 * Donut chart (top 5 languages)
 * Percentage-based slices
 * Calculated from public repositories
 
-### 💻 Competitive Programming (Optional)
+---
 
-* **LeetCode**: Total problems solved, difficulty breakdown, contest rating.
-* **Codeforces**: Current rating, max rating, rank.
-* **CodeChef**: Current rating, max rating, stars.
-* **Adaptive Layout**: Automatically organizes 1 or multiple platform stats cleanly.
+## 💻 Competitive Programming (Optional)
+
+* **LeetCode:** Total problems solved, difficulty breakdown, contest rating
+* **Codeforces:** Current rating, max rating, rank
+* **CodeChef:** Current rating, max rating, stars
+* **Adaptive Layout:** Automatically organizes 1 or multiple platform stats cleanly
 
 ---
 
-## 🏆 Achievement Trophies
+## 🎨 Extensive Theme Support
+
+* 20+ handcrafted dashboard themes
+* Modern dark, pastel, neon, and nature-inspired palettes
+* Consistent SVG rendering across charts and trophies
+* Optimized text contrast and readability
+
+---
+
+# 🏆 Achievement Trophies
 
 A visual trophy system highlighting GitHub milestones:
 
@@ -132,7 +170,7 @@ A visual trophy system highlighting GitHub milestones:
 | ---------------- | ------------------- |
 | 💪 Commits       | Total contributions |
 | 🔀 Pull Requests | PRs opened          |
-| 👁️ Reviews       | PR reviews          |
+| 👁️ Reviews      | PR reviews          |
 | 🐛 Issues        | Issues opened       |
 | 📦 Repositories  | Public repos        |
 | ⭐ Stars          | Total stars         |
@@ -150,28 +188,30 @@ A visual trophy system highlighting GitHub milestones:
 
 ---
 
-## ⚙️ Query Parameters
+# ⚙️ Query Parameters
 
-| Parameter  | Type           | Default     | Description                  |
-| ---------- | -------------- |-------------| ---------------------------- |
-| `username` | string         | `SamXop123` | GitHub username              |
-| `theme`    | string         | `dark`      | Visual theme                 |
-| `leetcode` | string / false | –           | LeetCode username            |
-| `codeforces` | string / false | –           | Codeforces username          |
-| `codechef`   | string / false | –           | CodeChef username            |
-| `align`    | string         | `left`      | Header alignment             |
-| `hide_trophies` | boolean   | `false`     | Hide the achievements trophies row |
+| Parameter       | Type           | Default     | Description                         |
+| --------------- | -------------- | ----------- | ----------------------------------- |
+| `username`      | string         | `SamXop123` | GitHub username                     |
+| `theme`         | string         | `dark`      | Visual theme (20+ supported themes) |
+| `leetcode`      | string / false | –           | LeetCode username                   |
+| `codeforces`    | string / false | –           | Codeforces username                 |
+| `codechef`      | string / false | –           | CodeChef username                   |
+| `align`         | string         | `left`      | Header alignment                    |
+| `hide_trophies` | boolean        | `false`     | Hide the achievements trophies row  |
 
 ---
 
-## 🛠️ Local Development
+# 🛠️ Local Development
 
-### Prerequisites
+## Prerequisites
 
 * Node.js 18+
 * GitHub Personal Access Token
 
-### Setup
+---
+
+## Setup
 
 ```bash
 git clone https://github.com/SamXop123/samdev-pulse.git
@@ -179,7 +219,11 @@ cd samdev-pulse
 npm install
 ```
 
-### Environment Variables
+---
+
+## Environment Variables
+
+Create a `.env` file:
 
 ```env
 GITHUB_TOKEN=your_github_personal_access_token
@@ -188,7 +232,9 @@ PORT=3000
 NODE_ENV=development
 ```
 
-### Run
+---
+
+## Run
 
 ```bash
 npm run dev
@@ -196,56 +242,58 @@ npm run dev
 
 Visit:
 
-```
+```txt
 http://localhost:3000/api/profile?username=SamXop123
 ```
 
 ---
 
-## 🔍 API
+# 🔍 API
 
-### `GET /api/profile`
+## GET `/api/profile`
 
 Returns an SVG dashboard.
 
-* Content-Type: `image/svg+xml`
-* Cache-Control: `public, max-age=1800`
+### Response Headers
 
-### `GET /health`
+* `Content-Type: image/svg+xml`
+* `Cache-Control: public, max-age=1800`
+
+---
+
+## GET `/health`
 
 Health check endpoint.
 
 ---
 
-## 📁 Project Structure
+# 📁 Project Structure
 
-```
+```txt
 src/
 ├── routes/        # API routes
-├── services/      # GitHub & LeetCode APIs
+├── services/      # GitHub & platform APIs
 ├── renderers/     # SVG layout & charts
 ├── themes/        # Theme definitions
 └── utils/         # Caching & helpers
 ```
 
+---
+
+# 🔒 Usage & Privacy
+
+samdev-pulse logs basic, non-sensitive usage information (such as the GitHub username passed to the API) for monitoring and improving the service.
+
+No personal data, authentication details, or private information is collected.
 
 ---
 
-## 🔒 Usage & privacy
-
-samdev-pulse logs basic, non-sensitive usage information (such as the github username passed to the api) for monitoring and improving the service.
-
-no personal data, authentication details, or private information is collected.
-
-
----
-
-## 🤝 Contributing
+# 🤝 Contributing
 
 Contributions are welcome.
 Please see `CONTRIBUTING.md` for guidelines.
 
-Ideas:
+### Ideas
 
 * More themes
 * New trophy categories
@@ -254,16 +302,13 @@ Ideas:
 
 ---
 
-## 📝 License
+# 📝 License
 
 MIT © [SamXop123](https://github.com/SamXop123)
 
 ---
 
-## ⭐ Support
+# ⭐ Support
 
 If this helped you, consider giving the repo a ⭐
 It helps more developers discover the project.
-
-
----

--- a/public/index.html
+++ b/public/index.html
@@ -75,7 +75,7 @@
       </div>
       <div class="hero-stats">
         <div class="stat-item">
-          <div class="stat-value">12+</div>
+          <div class="stat-value">20+</div>
           <div class="stat-label">Themes</div>
         </div>
         <div class="stat-divider"></div>
@@ -189,7 +189,7 @@
             </svg>
           </div>
           <h3 class="feature-title">Multi-Theme Support</h3>
-          <p class="feature-description">Choose from 12 stunning themes including Dark, Light, Dracula, Nord, Tokyo Night, Monokai, Gruvbox, Solarized, Catppuccin, Rose Pine, Aurora, and Midnight Sunset.</p>
+          <p class="feature-description">Choose from 20+ stunning themes including Dark, Light, Dracula, Nord, Tokyo Night, Monokai, Gruvbox, Solarized, Catppuccin, Rose Pine, Aurora, and Midnight Sunset.</p>
         </div>
 
         <div class="feature-card">
@@ -386,6 +386,110 @@
             <p class="theme-desc">Warm orange-pink sunset glow on dark violet</p>
           </div>
         </div>
+        <div class="theme-card" data-theme="onedarkpro">
+  <div class="theme-preview">
+    <div class="theme-swatch-group">
+      <div class="theme-swatch" style="background: #282c34;"></div>
+      <div class="theme-swatch" style="background: #61afef;"></div>
+      <div class="theme-swatch" style="background: #abb2bf;"></div>
+    </div>
+  </div>
+  <div class="theme-info">
+    <h4 class="theme-name">One Dark Pro</h4>
+    <p class="theme-desc">VS Code inspired modern editor palette</p>
+  </div>
+</div>
+<div class="theme-card" data-theme="material">
+  <div class="theme-preview">
+    <div class="theme-swatch-group">
+      <div class="theme-swatch" style="background: #263238;"></div>
+      <div class="theme-swatch" style="background: #29b6f6;"></div>
+      <div class="theme-swatch" style="background: #eceff1;"></div>
+    </div>
+  </div>
+  <div class="theme-info">
+    <h4 class="theme-name">Material</h4>
+    <p class="theme-desc">Material UI inspired soft modern tones</p>
+  </div>
+</div>
+<div class="theme-card" data-theme="synthwave84">
+  <div class="theme-preview">
+    <div class="theme-swatch-group">
+      <div class="theme-swatch" style="background: #241b2f;"></div>
+      <div class="theme-swatch" style="background: #ff7edb;"></div>
+      <div class="theme-swatch" style="background: #36f9f6;"></div>
+    </div>
+  </div>
+  <div class="theme-info">
+    <h4 class="theme-name">Synthwave 84</h4>
+    <p class="theme-desc">Retro neon cyberpunk aesthetics</p>
+  </div>
+</div>
+<div class="theme-card" data-theme="forestnight">
+  <div class="theme-preview">
+    <div class="theme-swatch-group">
+      <div class="theme-swatch" style="background: #0f1a14;"></div>
+      <div class="theme-swatch" style="background: #6ee7b7;"></div>
+      <div class="theme-swatch" style="background: #e8f5e9;"></div>
+    </div>
+  </div>
+  <div class="theme-info">
+    <h4 class="theme-name">Forest Night</h4>
+    <p class="theme-desc">Deep green nature-inspired palette</p>
+  </div>
+</div>
+<div class="theme-card" data-theme="oceanicnext">
+  <div class="theme-preview">
+    <div class="theme-swatch-group">
+      <div class="theme-swatch" style="background: #0f111a;"></div>
+      <div class="theme-swatch" style="background: #5fd7ff;"></div>
+      <div class="theme-swatch" style="background: #d8dee9;"></div>
+    </div>
+  </div>
+  <div class="theme-info">
+    <h4 class="theme-name">Oceanic Next</h4>
+    <p class="theme-desc">Cool ocean blues with coding vibes</p>
+  </div>
+</div>
+<div class="theme-card" data-theme="emberglow">
+  <div class="theme-preview">
+    <div class="theme-swatch-group">
+      <div class="theme-swatch" style="background: #1a0f0f;"></div>
+      <div class="theme-swatch" style="background: #ff7849;"></div>
+      <div class="theme-swatch" style="background: #fff1e6;"></div>
+    </div>
+  </div>
+  <div class="theme-info">
+    <h4 class="theme-name">Ember Glow</h4>
+    <p class="theme-desc">Warm fiery orange and crimson tones</p>
+  </div>
+</div>
+<div class="theme-card" data-theme="midnightneon">
+  <div class="theme-preview">
+    <div class="theme-swatch-group">
+      <div class="theme-swatch" style="background: #09090f;"></div>
+      <div class="theme-swatch" style="background: #00f5ff;"></div>
+      <div class="theme-swatch" style="background: #ff00ff;"></div>
+    </div>
+  </div>
+  <div class="theme-info">
+    <h4 class="theme-name">Midnight Neon</h4>
+    <p class="theme-desc">Futuristic glowing cyber aesthetics</p>
+  </div>
+</div>
+<div class="theme-card" data-theme="pasteldream">
+  <div class="theme-preview">
+    <div class="theme-swatch-group">
+      <div class="theme-swatch" style="background: #1f1d2b;"></div>
+      <div class="theme-swatch" style="background: #ffb3c1;"></div>
+      <div class="theme-swatch" style="background: #bde0fe;"></div>
+    </div>
+  </div>
+  <div class="theme-info">
+    <h4 class="theme-name">Pastel Dream</h4>
+    <p class="theme-desc">Soft dreamy pastel gradients and tones</p>
+  </div>
+</div>
       </div>
     </div>
   </section>
@@ -424,6 +528,14 @@
                 <option value="rose-pine">Rose Pine</option>
                 <option value="aurora">Aurora</option>
                 <option value="midnight-sunset">Midnight Sunset</option>
+                <option value="onedarkpro">One Dark Pro</option>
+               <option value="material">Material</option>
+              <option value="synthwave84">Synthwave 84</option>
+             <option value="forestnight">Forest Night</option>
+             <option value="oceanicnext">Oceanic Next</option>
+             <option value="emberglow">Ember Glow</option>
+           <option value="midnightneon">Midnight Neon</option>
+             <option value="pasteldream">Pastel Dream</option>
               </select>
             </div>
           </div>
@@ -561,7 +673,7 @@
               <td><code>theme</code></td>
               <td>string</td>
               <td><code>dark</code></td>
-              <td>Theme: dark, light, dracula, nord, tokyonight, monokai, gruvbox, solarized, catppuccin, rose-pine, aurora, midnight-sunset</td>
+              <td>Theme: dark, light, dracula, nord, tokyonight, monokai, gruvbox, solarized, catppuccin, rose-pine, aurora, midnight-sunset,onedarkpro,material,synthwave84,forestnight,oceanicnext,emberglow,midnightneon,pasteldream</td>
             </tr>
             <tr>
               <td><code>leetcode</code></td>

--- a/src/renderers/svg.renderer.js
+++ b/src/renderers/svg.renderer.js
@@ -28,6 +28,14 @@ import catppuccinTheme from '../themes/catppuccin.theme.js';
 import rosePineTheme from '../themes/rose-pine.theme.js';
 import auroraTheme from '../themes/aurora.theme.js';
 import midnightSunsetTheme from '../themes/midnight-sunset.theme.js';
+import oneDarkProTheme from '../themes/onedarkpro.theme.js';
+import materialTheme from '../themes/material.theme.js';
+import synthwave84Theme from '../themes/synthwave84.theme.js';
+import forestNightTheme from '../themes/forestnight.theme.js';
+import oceanicNextTheme from '../themes/oceanicnext.theme.js';
+import emberGlowTheme from '../themes/emberglow.theme.js';
+import midnightNeonTheme from '../themes/midnightneon.theme.js';
+import pastelDreamTheme from '../themes/pasteldream.theme.js';
 
 const LAYOUT = {
   width: 960,
@@ -51,6 +59,14 @@ const themes = {
   'rose-pine': rosePineTheme,
   aurora: auroraTheme,
   'midnight-sunset': midnightSunsetTheme,
+  onedarkpro: oneDarkProTheme,
+material: materialTheme,
+synthwave84: synthwave84Theme,
+forestnight: forestNightTheme,
+oceanicnext: oceanicNextTheme,
+emberglow: emberGlowTheme,
+midnightneon: midnightNeonTheme,
+pasteldream: pastelDreamTheme,
 };
 
 // current active theme

--- a/src/themes/emberglow.theme.js
+++ b/src/themes/emberglow.theme.js
@@ -1,0 +1,53 @@
+const emberGlowTheme = {
+  name: 'emberglow',
+
+  colors: {
+    // Main backgrounds
+    background: '#1a0f0f',
+    backgroundAlt: '#221414',
+    cardBackground: '#2d1b1b',
+    cardBackgroundAlt: '#382222',
+
+    // Borders & lines
+    border: '#4a2c2c',
+    borderLight: '#613737',
+    borderGlow: '#ff784933',
+
+    // Text
+    primaryText: '#fff1e6',
+    secondaryText: '#e7c3b0',
+    mutedText: '#b78d7a',
+
+    // Accents
+    accent: '#ff7849',
+    accentSecondary: '#ffb347',
+    accentTertiary: '#ff5e5b',
+    accentWarm: '#ffd166',
+    accentHot: '#ff3d3d',
+
+    // Gradients
+    gradientStart: '#ff7849',
+    gradientMid: '#ffb347',
+    gradientEnd: '#ff5e5b',
+
+    // Status colors
+    success: '#ffb347',
+    warning: '#ffd166',
+    error: '#ff3d3d',
+
+    // Special
+    glow: '#ff7849',
+    glowSecondary: '#ff5e5b',
+  },
+
+  chartColors: [
+    '#ff7849',
+    '#ffb347',
+    '#ff5e5b',
+    '#ffd166',
+    '#ff3d3d',
+    '#ff9f1c',
+  ],
+};
+
+export default emberGlowTheme;

--- a/src/themes/forestnight.theme.js
+++ b/src/themes/forestnight.theme.js
@@ -1,0 +1,53 @@
+const forestNightTheme = {
+  name: 'forestnight',
+
+  colors: {
+    // Main backgrounds
+    background: '#0f1a14',
+    backgroundAlt: '#132019',
+    cardBackground: '#1a2b22',
+    cardBackgroundAlt: '#22352b',
+
+    // Borders & lines
+    border: '#2d4739',
+    borderLight: '#3d5e4d',
+    borderGlow: '#6ee7b733',
+
+    // Text
+    primaryText: '#e8f5e9',
+    secondaryText: '#b7d3c0',
+    mutedText: '#87a494',
+
+    // Accents
+    accent: '#6ee7b7',
+    accentSecondary: '#34d399',
+    accentTertiary: '#a7f3d0',
+    accentWarm: '#facc15',
+    accentHot: '#fb7185',
+
+    // Gradients
+    gradientStart: '#6ee7b7',
+    gradientMid: '#34d399',
+    gradientEnd: '#a7f3d0',
+
+    // Status colors
+    success: '#34d399',
+    warning: '#facc15',
+    error: '#fb7185',
+
+    // Special
+    glow: '#6ee7b7',
+    glowSecondary: '#34d399',
+  },
+
+  chartColors: [
+    '#6ee7b7',
+    '#34d399',
+    '#a7f3d0',
+    '#facc15',
+    '#fb7185',
+    '#4ade80',
+  ],
+};
+
+export default forestNightTheme;

--- a/src/themes/material.theme.js
+++ b/src/themes/material.theme.js
@@ -1,0 +1,53 @@
+const materialTheme = {
+  name: 'material',
+
+  colors: {
+    // Main backgrounds
+    background: '#263238',
+    backgroundAlt: '#2e3c43',
+    cardBackground: '#32424a',
+    cardBackgroundAlt: '#3a4a52',
+
+    // Borders & lines
+    border: '#455a64',
+    borderLight: '#546e7a',
+    borderGlow: '#29b6f633',
+
+    // Text
+    primaryText: '#eceff1',
+    secondaryText: '#b0bec5',
+    mutedText: '#90a4ae',
+
+    // Accents
+    accent: '#29b6f6',
+    accentSecondary: '#66bb6a',
+    accentTertiary: '#ab47bc',
+    accentWarm: '#ffca28',
+    accentHot: '#ef5350',
+
+    // Gradients
+    gradientStart: '#29b6f6',
+    gradientMid: '#66bb6a',
+    gradientEnd: '#ab47bc',
+
+    // Status colors
+    success: '#66bb6a',
+    warning: '#ffca28',
+    error: '#ef5350',
+
+    // Special
+    glow: '#29b6f6',
+    glowSecondary: '#ab47bc',
+  },
+
+  chartColors: [
+    '#29b6f6',
+    '#66bb6a',
+    '#ab47bc',
+    '#ffca28',
+    '#ef5350',
+    '#26c6da',
+  ],
+};
+
+export default materialTheme;

--- a/src/themes/midnightneon.theme.js
+++ b/src/themes/midnightneon.theme.js
@@ -1,0 +1,53 @@
+const midnightNeonTheme = {
+  name: 'midnightneon',
+
+  colors: {
+    // Main backgrounds
+    background: '#09090f',
+    backgroundAlt: '#11111b',
+    cardBackground: '#151522',
+    cardBackgroundAlt: '#1d1d2e',
+
+    // Borders & lines
+    border: '#2a2a40',
+    borderLight: '#3b3b5c',
+    borderGlow: '#00f5ff33',
+
+    // Text
+    primaryText: '#f5f5ff',
+    secondaryText: '#b8b8d9',
+    mutedText: '#8c8cad',
+
+    // Accents
+    accent: '#00f5ff',
+    accentSecondary: '#ff00ff',
+    accentTertiary: '#8b5cf6',
+    accentWarm: '#ffe066',
+    accentHot: '#ff4d6d',
+
+    // Gradients
+    gradientStart: '#00f5ff',
+    gradientMid: '#8b5cf6',
+    gradientEnd: '#ff00ff',
+
+    // Status colors
+    success: '#22c55e',
+    warning: '#ffe066',
+    error: '#ff4d6d',
+
+    // Special
+    glow: '#00f5ff',
+    glowSecondary: '#ff00ff',
+  },
+
+  chartColors: [
+    '#00f5ff',
+    '#ff00ff',
+    '#8b5cf6',
+    '#ffe066',
+    '#ff4d6d',
+    '#22c55e',
+  ],
+};
+
+export default midnightNeonTheme;

--- a/src/themes/oceanicnext.theme.js
+++ b/src/themes/oceanicnext.theme.js
@@ -1,0 +1,53 @@
+const oceanicNextTheme = {
+  name: 'oceanicnext',
+
+  colors: {
+    // Main backgrounds
+    background: '#0f111a',
+    backgroundAlt: '#141826',
+    cardBackground: '#1b2030',
+    cardBackgroundAlt: '#22293d',
+
+    // Borders & lines
+    border: '#2f3b54',
+    borderLight: '#44506a',
+    borderGlow: '#5fd7ff33',
+
+    // Text
+    primaryText: '#d8dee9',
+    secondaryText: '#a7b1c2',
+    mutedText: '#7f8c9d',
+
+    // Accents
+    accent: '#5fd7ff',
+    accentSecondary: '#7fdbca',
+    accentTertiary: '#82aaff',
+    accentWarm: '#ffc777',
+    accentHot: '#ff757f',
+
+    // Gradients
+    gradientStart: '#5fd7ff',
+    gradientMid: '#82aaff',
+    gradientEnd: '#7fdbca',
+
+    // Status colors
+    success: '#7fdbca',
+    warning: '#ffc777',
+    error: '#ff757f',
+
+    // Special
+    glow: '#5fd7ff',
+    glowSecondary: '#82aaff',
+  },
+
+  chartColors: [
+    '#5fd7ff',
+    '#82aaff',
+    '#7fdbca',
+    '#ffc777',
+    '#ff757f',
+    '#c792ea',
+  ],
+};
+
+export default oceanicNextTheme;

--- a/src/themes/onedarkpro.theme.js
+++ b/src/themes/onedarkpro.theme.js
@@ -1,0 +1,53 @@
+const oneDarkProTheme = {
+  name: 'onedarkpro',
+
+  colors: {
+    // Main backgrounds
+    background: '#282c34',
+    backgroundAlt: '#21252b',
+    cardBackground: '#2c313c',
+    cardBackgroundAlt: '#353b45',
+
+    // Borders & lines
+    border: '#3e4451',
+    borderLight: '#4b5263',
+    borderGlow: '#61afef33',
+
+    // Text
+    primaryText: '#abb2bf',
+    secondaryText: '#828997',
+    mutedText: '#5c6370',
+
+    // Accents
+    accent: '#61afef',
+    accentSecondary: '#98c379',
+    accentTertiary: '#c678dd',
+    accentWarm: '#e5c07b',
+    accentHot: '#e06c75',
+
+    // Gradients
+    gradientStart: '#61afef',
+    gradientMid: '#98c379',
+    gradientEnd: '#c678dd',
+
+    // Status colors
+    success: '#98c379',
+    warning: '#e5c07b',
+    error: '#e06c75',
+
+    // Special
+    glow: '#61afef',
+    glowSecondary: '#c678dd',
+  },
+
+  chartColors: [
+    '#61afef',
+    '#98c379',
+    '#c678dd',
+    '#e5c07b',
+    '#e06c75',
+    '#56b6c2',
+  ],
+};
+
+export default oneDarkProTheme;

--- a/src/themes/pasteldream.theme.js
+++ b/src/themes/pasteldream.theme.js
@@ -1,0 +1,53 @@
+const pastelDreamTheme = {
+  name: 'pasteldream',
+
+  colors: {
+    // Main backgrounds
+    background: '#1f1d2b',
+    backgroundAlt: '#28243d',
+    cardBackground: '#312b45',
+    cardBackgroundAlt: '#3b3455',
+
+    // Borders & lines
+    border: '#4c4566',
+    borderLight: '#5d5677',
+    borderGlow: '#ffb3c133',
+
+    // Text
+    primaryText: '#f8f4ff',
+    secondaryText: '#d6cdea',
+    mutedText: '#aea4c9',
+
+    // Accents
+    accent: '#ffb3c1',
+    accentSecondary: '#bde0fe',
+    accentTertiary: '#caffbf',
+    accentWarm: '#ffd6a5',
+    accentHot: '#ff8fab',
+
+    // Gradients
+    gradientStart: '#ffb3c1',
+    gradientMid: '#bde0fe',
+    gradientEnd: '#caffbf',
+
+    // Status colors
+    success: '#caffbf',
+    warning: '#ffd6a5',
+    error: '#ff8fab',
+
+    // Special
+    glow: '#ffb3c1',
+    glowSecondary: '#bde0fe',
+  },
+
+  chartColors: [
+    '#ffb3c1',
+    '#bde0fe',
+    '#caffbf',
+    '#ffd6a5',
+    '#ff8fab',
+    '#a0c4ff',
+  ],
+};
+
+export default pastelDreamTheme;

--- a/src/themes/synthwave84.theme.js
+++ b/src/themes/synthwave84.theme.js
@@ -1,0 +1,53 @@
+const synthwave84Theme = {
+  name: 'synthwave84',
+
+  colors: {
+    // Main backgrounds
+    background: '#241b2f',
+    backgroundAlt: '#2d213f',
+    cardBackground: '#34294f',
+    cardBackgroundAlt: '#3d3060',
+
+    // Borders & lines
+    border: '#4b3b6e',
+    borderLight: '#5d4a87',
+    borderGlow: '#ff7edb33',
+
+    // Text
+    primaryText: '#f8f8f2',
+    secondaryText: '#c3b1e1',
+    mutedText: '#9d88c2',
+
+    // Accents
+    accent: '#ff7edb',
+    accentSecondary: '#72f1b8',
+    accentTertiary: '#36f9f6',
+    accentWarm: '#fede5d',
+    accentHot: '#ff5c8a',
+
+    // Gradients
+    gradientStart: '#ff7edb',
+    gradientMid: '#36f9f6',
+    gradientEnd: '#72f1b8',
+
+    // Status colors
+    success: '#72f1b8',
+    warning: '#fede5d',
+    error: '#ff5c8a',
+
+    // Special
+    glow: '#ff7edb',
+    glowSecondary: '#36f9f6',
+  },
+
+  chartColors: [
+    '#ff7edb',
+    '#36f9f6',
+    '#72f1b8',
+    '#fede5d',
+    '#ff5c8a',
+    '#9d7bff',
+  ],
+};
+
+export default synthwave84Theme;


### PR DESCRIPTION

This PR expands the dashboard customization system by introducing multiple new themes with full SVG rendering support and live preview integration.
Added Themes

* One Dark Pro
* Material
* Synthwave 84
* Forest Night
* Oceanic Next
* Ember Glow
* Midnight Neon
* Pastel Dream

Changes Made

* Added new theme configuration files
* Registered themes in the SVG renderer
* Added theme preview cards to the website
* Updated live preview dropdown options
* Updated README documentation and parameter table
* Increased total available theme count
* Ensured proper chart, trophy, and text contrast rendering across all themes

 Tested

* SVG rendering
* Contribution charts
* Trophy rendering
* Live preview integration
* Theme switching behavior
* Text visibility and contrast

Fixes #38
<img width="934" height="497" alt="image" src="https://github.com/user-attachments/assets/cee7b443-c904-4d05-8e8e-8dd4703adc24" />
<img width="901" height="367" alt="image" src="https://github.com/user-attachments/assets/56cccb46-12bf-42ab-b2be-342d181927cc" />
<img width="873" height="533" alt="image" src="https://github.com/user-attachments/assets/0cc608ac-d503-4000-90a9-30179bf523be" />


one  new theme  screenshots i have given all other are tested and working too.


