### PR TITLE
Add PNG export/download support for dashboard previews Downloadpng

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -572,14 +572,24 @@
               <label for="hide-trophies" style="margin-bottom: 0; cursor: pointer;">Hide Trophies</label>
             </div>
           </div>
-          <div class="preview-update-row">
-            <button id="update-preview-btn" class="btn btn-primary">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2" />
-              </svg>
-              Update Preview
-            </button>
-          </div>
+         <div class="preview-update-row">
+  <button id="update-preview-btn" class="btn btn-primary">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2" />
+    </svg>
+    Update Preview
+  </button>
+
+  <button id="download-png-btn" class="btn btn-secondary">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" stroke-width="2">
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" y1="15" x2="12" y2="3" />
+    </svg>
+    Download PNG
+  </button>
+</div>
         </div>
 
         <div class="preview-frame">

--- a/public/script.js
+++ b/public/script.js
@@ -13,6 +13,7 @@
   const snippet = document.getElementById('snippet');
   const copyBtn = document.getElementById('copy-btn');
   const updateBtn = document.getElementById('update-preview-btn');
+  const downloadBtn = document.getElementById('download-png-btn');
   const hideTrophiesCheck = document.getElementById('hide-trophies');
 
   // catching base URL
@@ -119,7 +120,92 @@
   }, 500);
 }
 
-  /* Handles copy button click */
+  /* Handles png download */
+  async function handleDownloadPng() {
+  if (!previewImg || !previewImg.src) {
+    alert('Preview not available');
+    return;
+  }
+
+  try {
+    downloadBtn.disabled = true;
+
+    downloadBtn.innerHTML = 'Generating PNG...';
+
+    // fetch SVG
+    const response = await fetch(previewImg.src);
+
+    const svgText = await response.text();
+
+    // create SVG blob
+    const svgBlob = new Blob([svgText], {
+      type: 'image/svg+xml;charset=utf-8',
+    });
+
+    const url = URL.createObjectURL(svgBlob);
+
+    // create image
+    const img = new Image();
+
+    img.onload = () => {
+      const scale = 3;
+
+      const canvas = document.createElement('canvas');
+
+      canvas.width = img.width * scale;
+      canvas.height = img.height * scale;
+
+      const ctx = canvas.getContext('2d');
+
+      // high quality scaling
+      ctx.setTransform(scale, 0, 0, scale, 0, 0);
+
+      ctx.imageSmoothingEnabled = true;
+      ctx.imageSmoothingQuality = 'high';
+
+      ctx.drawImage(img, 0, 0);
+
+      // convert canvas → png
+      canvas.toBlob((blob) => {
+        const pngUrl = URL.createObjectURL(blob);
+
+        const a = document.createElement('a');
+
+        const username =
+          usernameInput.value.trim() || 'github-user';
+
+        a.href = pngUrl;
+
+        a.download = `${username}-samdev-pulse.png`;
+
+        document.body.appendChild(a);
+
+        a.click();
+
+        document.body.removeChild(a);
+
+        URL.revokeObjectURL(pngUrl);
+      }, 'image/png');
+
+      URL.revokeObjectURL(url);
+
+      downloadBtn.disabled = false;
+
+      downloadBtn.innerHTML = 'Download PNG';
+    };
+
+    img.src = url;
+
+  } catch (error) {
+    console.error(error);
+
+    downloadBtn.disabled = false;
+
+    downloadBtn.innerHTML = 'Download PNG';
+
+    alert('Failed to generate PNG');
+  }
+}
   async function handleCopyClick() {
     if (!copyBtn || !snippet) return;
 
@@ -199,6 +285,9 @@
     if (updateBtn) {
       updateBtn.addEventListener('click', handleUpdateClick);
     }
+    if (downloadBtn) {
+  downloadBtn.addEventListener('click', handleDownloadPng);
+}
 
     if (copyBtn) {
       copyBtn.addEventListener('click', handleCopyClick);

--- a/public/styles.css
+++ b/public/styles.css
@@ -499,6 +499,11 @@ section{
   padding: 1.125rem 2.25rem;
   font-size: 1.125rem;
 }
+.preview-update-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
 
 
 /* ===== Section Styling ===== */


### PR DESCRIPTION
## Description

Added PNG export support for generated dashboard previews.

Users can now download their rendered SVG dashboard as a high-quality PNG image directly from the live preview section.

## Features Added

- Added "Download PNG" button near live preview
- Converts rendered SVG dashboard into PNG format
- Automatically downloads generated image
- Preserves:
  - selected theme
  - layout
  - charts/cards styling
  - typography and gradients
- Added high-resolution scaling for sharper exports

## Why This Matters

This helps users use their dashboards in:
- portfolios
- resumes
- LinkedIn posts
- websites
- social media graphics

where PNG support is preferred over SVG embeds.

## Tested

- SVG → PNG conversion
- Multiple themes
- Large dashboards
- High-resolution export quality
- Auto-download behavior

<img width="1887" height="778" alt="image" src="https://github.com/user-attachments/assets/53f362a1-5ae3-4169-9620-02726af0747f" />
<img width="1699" height="958" alt="image" src="https://github.com/user-attachments/assets/73f46d03-3560-4072-993c-cc1f442515e3" />
<img width="1399" height="871" alt="image" src="https://github.com/user-attachments/assets/c30a13ee-8d77-484c-9e8f-0ad968791d91" />
