### PR TITLE
fix: resolve horizontal scrollbar overlap on Quick Start Guide cards

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -947,8 +947,33 @@ section {
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   padding: var(--spacing-md);
+  padding-bottom: 1.25rem; /* Ensure enough bottom padding so scrollbar doesn't overlap text */
   font-size: 0.8125rem;
   word-break: break-all;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-light) var(--bg-primary);
+}
+
+.usage-card .code-block::-webkit-scrollbar {
+  height: 6px;
+}
+
+.usage-card .code-block::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.usage-card .code-block::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: var(--radius-sm);
+  transition: background var(--transition-base);
+}
+
+.usage-card:hover .code-block::-webkit-scrollbar-thumb {
+  background: var(--border-light);
+}
+
+.usage-card:hover .code-block::-webkit-scrollbar-thumb:hover {
+  background: var(--accent-purple);
 }
 
 .params-table {


### PR DESCRIPTION
## Description
On desktop and specific screen resolutions, the horizontal scrollbars on the single-line code snippet cards in the **Quick Start Guide** section rendered directly on top of the code text, obscuring the bottom half of the font and making the instructions difficult to read or copy.

This Pull Request resolves the overlap by increasing the bottom padding of the code blocks and adding custom, elegant custom scrollbar styles that match the site's dark aesthetic.

## Key Changes
- **Scrollbar Clearance**: Increased `padding-bottom` to `1.25rem` (`20px`) inside `.usage-card .code-block` to push the scrollbar entirely below the text.
- **Premium Hover-Reveal Scrollbar**: Custom Webkit styling makes the scrollbar thumb `6px` and fully transparent by default, smoothly fading into view only when the respective card is hovered. 
- **Transparent Track**: Removed the bulky dark-grey track background so the scrollbars blend seamlessly with the card container.
- **Cross-Browser Styling**: Added `scrollbar-width: thin` and `scrollbar-color` properties for clean rendering in Firefox.

## Visual Comparison

| Before (Chunky Overlapping Scrollbars) | 
<img width="1807" height="866" alt="Screenshot 2026-05-19 224104" src="https://github.com/user-attachments/assets/3e6feab5-6483-41e3-a725-1b5377c6603d" />
|After (Sleek Hover-Reveal Scrollbars below code) |
<img width="1706" height="795" alt="Screenshot 2026-05-20 123309" src="https://github.com/user-attachments/assets/449929d7-962b-4516-aed8-8c96a0ec74d7" />




