### PR TITLE
fix: remove empty textLength and lengthAdjust SVG attributes

### DIFF
--- a/src/renderers/svg.renderer.js
+++ b/src/renderers/svg.renderer.js
@@ -219,7 +219,7 @@ export function renderStatItem({ x, y, label, value, icon, accentColor, showProg
   return `
   <g>
     ${iconElement}
-    <text x="${x}" y="${y}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="${fontSize}" font-weight="700" fill="${colors.primaryText}" textLength="${valueStr.length > 10 ? '90' : ''}" lengthAdjust="${valueStr.length > 10 ? 'spacingAndGlyphs' : ''}">${value}</text>
+    <text x="${x}" y="${y}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="${fontSize}" font-weight="700" fill="${colors.primaryText}" ${valueStr.length > 10 ? 'textLength="90" lengthAdjust="spacingAndGlyphs"' : ''}>${value}</text>
     <text x="${x}" y="${y + 20}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">${label}</text>
     ${progressBar}
   </g>`;


### PR DESCRIPTION
## What does this PR fix?
Fixes #42

## Problem
SVG `<text>` elements in `renderStatItem()` were setting 
`textLength=""` and `lengthAdjust=""` as empty strings when 
the value length was 10 characters or less, causing browser 
console errors:
- `attribute textLength: Unexpected end of attribute. Expected length, ""`
- `attribute lengthAdjust: Unexpected end of attribute. Unrecognized enumerated value, ""`

## Fix
Changed the conditional so that when the value is short, 
the attributes are completely omitted from the SVG output 
instead of being set to empty strings.

## Before
textLength="${valueStr.length > 10 ? '90' : ''}" lengthAdjust="${valueStr.length > 10 ? 'spacingAndGlyphs' : ''}"

## After
${valueStr.length > 10 ? 'textLength="90" lengthAdjust="spacingAndGlyphs"' : ''}

## Testing
- Loaded profile dashboard in Chrome
- Verified console errors are gone after the fix
- Confirmed long values (>10 chars) still render correctly