### PR TITLE
fix: restore SVG icon on Download PNG button after click

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -119,6 +119,15 @@
     `;
   }, 500);
 }
+  const DOWNLOAD_BTN_HTML = `
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" stroke-width="2">
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" y1="15" x2="12" y2="3" />
+    </svg>
+    Download PNG
+  `;
 
   /* Handles png download */
   async function handleDownloadPng() {
@@ -190,8 +199,7 @@
       URL.revokeObjectURL(url);
 
       downloadBtn.disabled = false;
-
-      downloadBtn.innerHTML = 'Download PNG';
+      downloadBtn.innerHTML = DOWNLOAD_BTN_HTML;
     };
 
     img.src = url;
@@ -200,8 +208,7 @@
     console.error(error);
 
     downloadBtn.disabled = false;
-
-    downloadBtn.innerHTML = 'Download PNG';
+    downloadBtn.innerHTML = DOWNLOAD_BTN_HTML; 
 
     alert('Failed to generate PNG');
   }


### PR DESCRIPTION
Fixes a visual bug where the **Download PNG** button loses its SVG icon after being clicked. The button reverted to plain text on both the success and error paths, while the original HTML renders it with a download arrow icon.

Closes #49

---

## What Changed

**`public/script.js`**

- Added a `DOWNLOAD_BTN_HTML` constant holding the original button `innerHTML` (SVG icon + label), matching the markup in `index.html`
- Replaced both plain `downloadBtn.innerHTML = 'Download PNG'` resets (success path and error path) with `downloadBtn.innerHTML = DOWNLOAD_BTN_HTML`
