### PR TITLE
Enhancement: return graceful error SVG when GitHub API fails 

### DIFF
--- a/src/renderers/error.renderer.js
+++ b/src/renderers/error.renderer.js
@@ -38,7 +38,8 @@ function escapeXml(str) {
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
 }
 
 /**
@@ -53,7 +54,7 @@ export function renderGracefulError({ code = 'API_ERROR', username, detail }) {
   const cardWidth = width - padding * 2;
   const cardHeight = 168;
   const cardX = padding;
-  const cardY = 52;
+  const cardY = 50;
   const centerX = width / 2;
 
   const usernameLine = username ? `@${escapeXml(username)}` : '';
@@ -73,7 +74,7 @@ export function renderGracefulError({ code = 'API_ERROR', username, detail }) {
     `<text x="${centerX}" y="${cardY + (usernameLine ? 136 : 120)}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="${colors.secondaryText}" text-anchor="middle">${escapeXml(copy.message)}</text>`,
     `<text x="${centerX}" y="${cardY + (usernameLine ? 154 : 138)}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="${colors.mutedText}" text-anchor="middle">${escapeXml(copy.hint)}</text>`,
     detailLine
-      ? `<text x="${centerX}" y="${cardY + 172}" font-family="monospace" font-size="10" fill="${colors.mutedText}" text-anchor="middle" opacity="0.7">${detailLine}</text>`
+      ? `<text x="${centerX}" y="${cardY + 182}" font-family="monospace" font-size="10" fill="${colors.mutedText}" text-anchor="middle" opacity="0.7">${detailLine}</text>`
       : '',
   ].filter(Boolean).join('\n');
 

--- a/src/renderers/error.renderer.js
+++ b/src/renderers/error.renderer.js
@@ -1,0 +1,89 @@
+import { renderBackground, wrapSvg, renderCard, LAYOUT, getTheme } from './svg.renderer.js';
+
+const ERROR_COPY = {
+  NOT_FOUND: {
+    title: 'User Not Found',
+    message: 'This GitHub username does not exist or is not accessible.',
+    hint: 'Check the spelling in your README embed URL.',
+  },
+  RATE_LIMIT: {
+    title: 'Rate Limit Reached',
+    message: 'GitHub API rate limit exceeded.',
+    hint: 'The dashboard will recover once limits reset.',
+  },
+  API_DOWN: {
+    title: 'GitHub API Unavailable',
+    message: 'GitHub is temporarily unreachable.',
+    hint: 'Try refreshing your profile in a few minutes.',
+  },
+  NETWORK: {
+    title: 'Connection Error',
+    message: 'Could not reach GitHub.',
+    hint: 'Check your connection or try again shortly.',
+  },
+  API_ERROR: {
+    title: 'Unable to Load Profile',
+    message: 'Something went wrong while fetching GitHub data.',
+    hint: 'Verify your username and try again.',
+  },
+  INVALID_USERNAME: {
+    title: 'Invalid GitHub Username',
+    message: 'Usernames must be 1–39 characters: letters, numbers, or hyphens.',
+    hint: 'Cannot start or end with a hyphen.',
+  },
+};
+
+function escapeXml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Renders a themed error dashboard SVG inside the samdev-pulse frame.
+ */
+export function renderGracefulError({ code = 'API_ERROR', username, detail }) {
+  const copy = ERROR_COPY[code] || ERROR_COPY.API_ERROR;
+  const { colors } = getTheme();
+  const width = LAYOUT.width;
+  const height = 240;
+  const padding = LAYOUT.padding;
+  const cardWidth = width - padding * 2;
+  const cardHeight = 168;
+  const cardX = padding;
+  const cardY = 52;
+  const centerX = width / 2;
+
+  const usernameLine = username ? `@${escapeXml(username)}` : '';
+  const detailLine = detail ? escapeXml(detail) : '';
+
+  const content = [
+    renderBackground(width, height),
+    `<text x="${padding}" y="36" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="17" font-weight="700" fill="${colors.primaryText}">samdev-pulse</text>`,
+    `<text x="${width - padding}" y="36" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="${colors.mutedText}" text-anchor="end">dashboard</text>`,
+    renderCard({ x: cardX, y: cardY, width: cardWidth, height: cardHeight, title: 'Status' }),
+    `<circle cx="${centerX}" cy="${cardY + 58}" r="24" fill="${colors.error}" opacity="0.12"/>`,
+    `<text x="${centerX}" y="${cardY + 66}" font-family="Arial, sans-serif" font-size="26" font-weight="700" fill="${colors.error}" text-anchor="middle">!</text>`,
+    `<text x="${centerX}" y="${cardY + 98}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="19" font-weight="700" fill="${colors.error}" text-anchor="middle">${escapeXml(copy.title)}</text>`,
+    usernameLine
+      ? `<text x="${centerX}" y="${cardY + 118}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="${colors.accent}" text-anchor="middle">${usernameLine}</text>`
+      : '',
+    `<text x="${centerX}" y="${cardY + (usernameLine ? 136 : 120)}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" fill="${colors.secondaryText}" text-anchor="middle">${escapeXml(copy.message)}</text>`,
+    `<text x="${centerX}" y="${cardY + (usernameLine ? 154 : 138)}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="${colors.mutedText}" text-anchor="middle">${escapeXml(copy.hint)}</text>`,
+    detailLine
+      ? `<text x="${centerX}" y="${cardY + 172}" font-family="monospace" font-size="10" fill="${colors.mutedText}" text-anchor="middle" opacity="0.7">${detailLine}</text>`
+      : '',
+  ].filter(Boolean).join('\n');
+
+  return wrapSvg(content, width, height);
+}
+
+/** Sends graceful error SVG (HTTP 200 so README img embeds do not break). */
+export function sendGracefulErrorSvg(res, { code, username, detail }) {
+  const svg = renderGracefulError({ code, username, detail });
+  res.setHeader('Content-Type', 'image/svg+xml');
+  res.setHeader('Cache-Control', 'public, max-age=300');
+  return res.status(200).send(svg);
+}

--- a/src/routes/profile.route.js
+++ b/src/routes/profile.route.js
@@ -17,6 +17,8 @@ import { getLeetCodeData } from '../services/leetcode.service.js';
 import { getCodeforcesData } from '../services/codeforces.service.js';
 import { getCodeChefData } from '../services/codechef.service.js';
 import { renderCPSection } from '../renderers/cp-section.renderer.js';
+import { sendGracefulErrorSvg } from '../renderers/error.renderer.js';
+import { GitHubErrorCode } from '../services/github.service.js';
 import { logApiAccess } from '../utils/logger.js';
 
 const router = Router();
@@ -56,9 +58,11 @@ function getTopLanguages(repos, max = 5) {
 }
 
 router.get('/', async (req, res) => {
+  try {
   logApiAccess(req).catch(err => console.error('Log failed:', err.message));
 
   const { theme, leetcode, align, hide_trophies, codeforces, codechef } = req.query;
+  setTheme(theme || 'dark');
 
   const rawUsername = typeof req.query.username === 'string' ? req.query.username : '';
   const usernameRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$|^[a-zA-Z0-9]$/;
@@ -67,25 +71,13 @@ router.get('/', async (req, res) => {
   if (!rawUsername) {
     username = DEFAULT_USERNAME;
   } else if (!usernameRegex.test(rawUsername)) {
-    const errorSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="600" height="120">
-      <rect width="600" height="120" rx="10" fill="#0d1117" />
-      <text x="300" y="50" font-family="Arial" font-size="16" fill="#f87171" text-anchor="middle" font-weight="bold">
-        ⚠ Invalid GitHub Username
-      </text>
-      <text x="300" y="78" font-family="Arial" font-size="12" fill="#8b949e" text-anchor="middle">
-        Usernames must be 1–39 characters, alphanumeric or hyphens only,
-      </text>
-      <text x="300" y="98" font-family="Arial" font-size="12" fill="#8b949e" text-anchor="middle">
-        and cannot start or end with a hyphen.
-      </text>
-    </svg>`;
-    res.setHeader('Content-Type', 'image/svg+xml');
-    return res.status(400).send(errorSvg);
+    return sendGracefulErrorSvg(res, {
+      code: 'INVALID_USERNAME',
+      username: rawUsername,
+    });
   } else {
     username = rawUsername;
   }
-
-  setTheme(theme || 'dark');
 
   const leetcodeDisabled = leetcode === 'false';
   const shouldRenderLeetCode = Boolean(leetcode && !leetcodeDisabled);
@@ -97,7 +89,11 @@ router.get('/', async (req, res) => {
 
   const result = await getGitHubUserData(username);
   if (!result.success) {
-    return res.status(500).json({ error: result.error });
+    return sendGracefulErrorSvg(res, {
+      code: result.code || GitHubErrorCode.API_ERROR,
+      username,
+      detail: result.error,
+    });
   }
   const { data } = result;
 
@@ -288,6 +284,14 @@ router.get('/', async (req, res) => {
   res.setHeader('Content-Type', 'image/svg+xml');
   res.setHeader('Cache-Control', 'public, max-age=1800');
   res.send(svg);
+  } catch (error) {
+    console.error('Profile render failed:', error.message);
+    return sendGracefulErrorSvg(res, {
+      code: GitHubErrorCode.API_ERROR,
+      username: typeof req.query.username === 'string' ? req.query.username : undefined,
+      detail: error.message,
+    });
+  }
 });
 
 export default router;

--- a/src/services/github.service.js
+++ b/src/services/github.service.js
@@ -4,6 +4,48 @@ import { githubCache } from '../utils/cache.js';
 
 const GITHUB_API_BASE = 'https://api.github.com';
 
+export const GitHubErrorCode = {
+  NOT_FOUND: 'NOT_FOUND',
+  RATE_LIMIT: 'RATE_LIMIT',
+  API_DOWN: 'API_DOWN',
+  API_ERROR: 'API_ERROR',
+  NETWORK: 'NETWORK',
+};
+
+class GitHubRequestError extends Error {
+  constructor(message, code, status = 0) {
+    super(message);
+    this.name = 'GitHubRequestError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function errorFromStatus(status) {
+  if (status === 404) {
+    return new GitHubRequestError('User not found', GitHubErrorCode.NOT_FOUND, 404);
+  }
+  if (status === 403) {
+    return new GitHubRequestError(
+      'GitHub API rate limit exceeded',
+      GitHubErrorCode.RATE_LIMIT,
+      403
+    );
+  }
+  if (status >= 500) {
+    return new GitHubRequestError(
+      'GitHub API is temporarily unavailable',
+      GitHubErrorCode.API_DOWN,
+      status
+    );
+  }
+  return new GitHubRequestError(
+    `GitHub API error: ${status}`,
+    GitHubErrorCode.API_ERROR,
+    status
+  );
+}
+
 /* function to get authorization headers once to use it everywhere */
 function getHeaders() {
   const headers = {
@@ -18,16 +60,19 @@ function getHeaders() {
   return headers;
 }
 
+async function assertOk(response) {
+  if (!response.ok) {
+    throw errorFromStatus(response.status);
+  }
+}
+
 /* fetch user profile from GitHub API */
 async function fetchUserProfile(username) {
   const response = await fetch(`${GITHUB_API_BASE}/users/${username}`, {
     headers: getHeaders(),
   });
 
-  if (!response.ok) {
-    throw new Error(`GitHub API error: ${response.status}`);
-  }
-
+  await assertOk(response);
   return response.json();
 }
 
@@ -43,9 +88,7 @@ async function fetchUserRepos(username) {
       { headers: getHeaders() }
     );
 
-    if (!response.ok) {
-      throw new Error(`GitHub API error: ${response.status}`);
-    }
+    await assertOk(response);
 
     const data = await response.json();
     repos.push(...data);
@@ -87,7 +130,7 @@ async function fetchAvatarDataUri(avatarUrl) {
     const buffer = Buffer.from(await response.arrayBuffer());
     const base64 = buffer.toString('base64');
     return `data:${contentType};base64,${base64}`;
-  } catch (error) {
+  } catch {
     return null;
   }
 }
@@ -124,7 +167,6 @@ function normalizeUserData(profile, repos, avatarDataUri) {
 
 /* fetch and normalize all gitHub data for a user */
 export async function getGitHubUserData(username) {
-  // checks cache first
   const cached = githubCache.get(username);
   if (cached) {
     return cached;
@@ -141,14 +183,23 @@ export async function getGitHubUserData(username) {
       data: normalizeUserData(profile, repos, avatarDataUri),
     };
 
-    // store in cache
     githubCache.set(username, result);
 
     return result;
   } catch (error) {
+    if (error instanceof GitHubRequestError) {
+      return {
+        success: false,
+        error: error.message,
+        code: error.code,
+        status: error.status,
+      };
+    }
+
     return {
       success: false,
       error: error.message || 'Failed to fetch GitHub data',
+      code: GitHubErrorCode.NETWORK,
     };
   }
 }


### PR DESCRIPTION
resolves issue #6 

## Before
API failure → JSON + 500 → broken image on GitHub.

## After
API failure → same pipeline as success (theme + SVG frame) → still a valid image with a clear message.

## Manual tests (passed)
Non-existent user → 200 + SVG with “User Not Found”
Invalid username → 200 + “Invalid GitHub Username”
Valid user → normal dashboard SVG

## Current changes Images 

- Image 1- 
<img width="1664" height="465" alt="image" src="https://github.com/user-attachments/assets/6deb8a50-511a-4cdb-b986-9d633211ca5f" />


- Image 2
<img width="1620" height="1136" alt="image" src="https://github.com/user-attachments/assets/0e3875a5-ec0a-46fb-b150-4c9320a83865" />
