### PR TITLE
Add centralized SVG sanitization utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "node --watch src/server.js",
-    "test": "node test-deployment.js"
+    "test": "node test-deployment.js",
+    "test:unit": "node --test src/utils/svg-sanitizer.test.js"
   },
   "keywords": [
     "github",

--- a/src/renderers/chart.renderer.js
+++ b/src/renderers/chart.renderer.js
@@ -1,6 +1,7 @@
 // Chart Renderer
 
 import { getTheme, LAYOUT } from './svg.renderer.js';
+import { sanitizeSvgValue } from '../utils/svg-sanitizer.js';
 
 // generate a smooth SVG path using cardinal spline interpolation
 function smoothPath(points) {
@@ -85,6 +86,8 @@ export function renderLineChart({
   xTickLabels = [],
 }) {
   const { colors } = getTheme();
+  const safeXLabel = sanitizeSvgValue(xLabel);
+  const safeYLabel = sanitizeSvgValue(yLabel);
   const padding = 12;
   const id = uniqueId || `chart-${x}-${y}`;
   const maxVal = Math.max(...data);
@@ -150,17 +153,18 @@ export function renderLineChart({
     yTicks.forEach((tick) => {
       const yPos = topY + tick.ratio * (bottomY - topY);
       elements.push(`<line x1="${leftX - 4}" y1="${yPos}" x2="${leftX}" y2="${yPos}" stroke="${colors.secondaryText}" stroke-width="1" opacity="0.7"/>`);
-      elements.push(`<text x="${leftX - 8}" y="${yPos + 3}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8.5" fill="${colors.mutedText}" text-anchor="end">${tick.value}</text>`);
+      elements.push(`<text x="${leftX - 8}" y="${yPos + 3}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8.5" fill="${colors.mutedText}" text-anchor="end">${sanitizeSvgValue(tick.value)}</text>`);
     });
 
     xTicks.forEach((tick) => {
       const xPos = leftX + tick.ratio * (rightX - leftX);
+      const safeTickLabel = sanitizeSvgValue(tick.label);
       elements.push(`<line x1="${xPos}" y1="${bottomY}" x2="${xPos}" y2="${bottomY + 4}" stroke="${colors.secondaryText}" stroke-width="1" opacity="0.7"/>`);
-      elements.push(`<text x="${xPos}" y="${bottomY + 14}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8.5" fill="${colors.mutedText}" text-anchor="middle">${tick.label}</text>`);
+      elements.push(`<text x="${xPos}" y="${bottomY + 14}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="8.5" fill="${colors.mutedText}" text-anchor="middle">${safeTickLabel}</text>`);
     });
 
-    elements.push(`<text x="${(leftX + rightX) / 2}" y="${height + 22}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" fill="${colors.secondaryText}" text-anchor="middle">${xLabel}</text>`);
-    elements.push(`<text x="${leftX - 36}" y="${(topY + bottomY) / 2}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" fill="${colors.secondaryText}" text-anchor="middle" transform="rotate(-90, ${leftX - 36}, ${(topY + bottomY) / 2})">${yLabel}</text>`);
+    elements.push(`<text x="${(leftX + rightX) / 2}" y="${height + 22}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" fill="${colors.secondaryText}" text-anchor="middle">${safeXLabel}</text>`);
+    elements.push(`<text x="${leftX - 36}" y="${(topY + bottomY) / 2}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" fill="${colors.secondaryText}" text-anchor="middle" transform="rotate(-90, ${leftX - 36}, ${(topY + bottomY) / 2})">${safeYLabel}</text>`);
   }
 
   // area fill with gradient
@@ -208,6 +212,7 @@ export function renderLineChart({
 // render a modern contribution chart card
 export function renderContributionChart({ x, y, width, height, title, data }) {
   const { colors } = getTheme();
+  const safeTitle = sanitizeSvgValue(String(title).toUpperCase());
   const chartX = 0;
   const chartY = 44;
   const chartWidth = width - 40;
@@ -235,7 +240,7 @@ export function renderContributionChart({ x, y, width, height, title, data }) {
     <rect x="${x + 0.5}" y="${y + 0.5}" width="${width - 1}" height="${height - 1}" rx="${LAYOUT.cardRadius}" ry="${LAYOUT.cardRadius}" fill="none" stroke="${colors.borderLight}" stroke-width="1" opacity="0.4"/>
     
     <!-- title -->
-    <text x="${x + 20}" y="${y + 28}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="600" fill="${colors.secondaryText}" letter-spacing="0.5">${title.toUpperCase()}</text>
+    <text x="${x + 20}" y="${y + 28}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="600" fill="${colors.secondaryText}" letter-spacing="0.5">${safeTitle}</text>
     
     <!-- title accent -->
     <rect x="${x + 20}" y="${y + 36}" width="28" height="2" rx="1" fill="url(#accentGradient)" opacity="0.7"/>
@@ -322,6 +327,7 @@ function describeArc(cx, cy, outerR, innerR, startAngle, endAngle) {
 // render a modern donut chart with legend
 export function renderDonutChart({ x, y, width, height, title, data }) {
   const { colors, chartColors } = getTheme();
+  const safeTitle = sanitizeSvgValue(String(title).toUpperCase());
 
   // donut dimensions
   const chartAreaWidth = width * 0.42;
@@ -354,7 +360,7 @@ export function renderDonutChart({ x, y, width, height, title, data }) {
   const centerDeco = `
     <circle cx="${centerX}" cy="${centerY}" r="${innerRadius - 4}" fill="${colors.cardBackground}" opacity="0.9"/>
     <circle cx="${centerX}" cy="${centerY}" r="${innerRadius - 8}" fill="url(#mainGradient)" opacity="0.5"/>
-    <text x="${centerX}" y="${centerY + 4}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="${colors.primaryText}" text-anchor="middle">${total}</text>
+    <text x="${centerX}" y="${centerY + 4}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="16" font-weight="700" fill="${colors.primaryText}" text-anchor="middle">${sanitizeSvgValue(total)}</text>
     <text x="${centerX}" y="${centerY + 18}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" fill="${colors.mutedText}" text-anchor="middle">REPOS</text>
   `;
 
@@ -367,13 +373,15 @@ export function renderDonutChart({ x, y, width, height, title, data }) {
     const itemY = legendStartY + i * legendItemHeight;
     const percentage = ((item.value / total) * 100).toFixed(0);
     const color = chartColors[i % chartColors.length];
+    const safeLabel = sanitizeSvgValue(item.label);
+    const safePercentage = sanitizeSvgValue(`${percentage}%`);
 
     return `
       <g>
         <rect x="${legendX - 2}" y="${itemY - 8}" width="${width - chartAreaWidth - 50}" height="24" rx="6" fill="${color}" opacity="0.08"/>
         <circle cx="${legendX + 6}" cy="${itemY + 4}" r="4" fill="${color}"/>
-        <text x="${legendX + 18}" y="${itemY + 8}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="500" fill="${colors.primaryText}">${item.label}</text>
-        <text x="${x + width - 24}" y="${itemY + 8}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="${color}" text-anchor="end">${percentage}%</text>
+        <text x="${legendX + 18}" y="${itemY + 8}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="500" fill="${colors.primaryText}">${safeLabel}</text>
+        <text x="${x + width - 24}" y="${itemY + 8}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="${color}" text-anchor="end">${safePercentage}</text>
       </g>
     `;
   }).join('');
@@ -393,7 +401,7 @@ export function renderDonutChart({ x, y, width, height, title, data }) {
     <rect x="${x + 0.5}" y="${y + 0.5}" width="${width - 1}" height="${height - 1}" rx="${LAYOUT.cardRadius}" ry="${LAYOUT.cardRadius}" fill="none" stroke="${colors.borderLight}" stroke-width="1" opacity="0.4"/>
     
     <!-- title -->
-    <text x="${x + 20}" y="${y + 28}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="600" fill="${colors.secondaryText}" letter-spacing="0.5">${title.toUpperCase()}</text>
+    <text x="${x + 20}" y="${y + 28}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="600" fill="${colors.secondaryText}" letter-spacing="0.5">${safeTitle}</text>
     
     <!-- title accent -->
     <rect x="${x + 20}" y="${y + 36}" width="28" height="2" rx="1" fill="url(#accentGradient)" opacity="0.7"/>

--- a/src/renderers/cp-section.renderer.js
+++ b/src/renderers/cp-section.renderer.js
@@ -1,4 +1,5 @@
 import { getTheme } from './svg.renderer.js';
+import { sanitizeSvgValue } from '../utils/svg-sanitizer.js';
 
 const CARD_RADIUS = 16;
 const CARD_GAP = 16;
@@ -38,6 +39,7 @@ export function renderCPSection({ x, y, width, leetcode, codeforces, codechef })
   const cards = platforms.map((platform, i) => {
     const cardX = x + i * (cardWidth + CARD_GAP);
     const cardY = y;
+    const safePlatformTitle = sanitizeSvgValue(platform.title.toUpperCase());
 
     return `
       <g>
@@ -58,7 +60,7 @@ export function renderCPSection({ x, y, width, leetcode, codeforces, codechef })
           font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
           font-size="13" font-weight="600"
           fill="${colors.secondaryText}"
-          letter-spacing="0.5">${platform.title.toUpperCase()}</text>
+          letter-spacing="0.5">${safePlatformTitle}</text>
         <rect x="${cardX + 20}" y="${cardY + 40}" width="28" height="2"
           rx="1" fill="url(#accentGradient)" opacity="0.7"/>
         ${platform.render(cardX, cardY, cardWidth)}
@@ -77,11 +79,16 @@ function renderLeetCodeCard(x, y, width, data, colors) {
 
   const solved = String(data.totalSolved ?? 0);
   const rating = String(data.contestRating ?? data.ranking ?? 'N/A');
+  const safeSolved = sanitizeSvgValue(solved);
+  const safeEasySolved = sanitizeSvgValue(data.easySolved ?? 0);
+  const safeMediumSolved = sanitizeSvgValue(data.mediumSolved ?? 0);
+  const safeHardSolved = sanitizeSvgValue(data.hardSolved ?? 0);
+  const safeRating = sanitizeSvgValue(rating);
 
   return `
     <text x="${col1X}" y="${statsY}"
       font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
-      font-size="32" font-weight="700" fill="${colors.primaryText}">${solved}</text>
+      font-size="32" font-weight="700" fill="${colors.primaryText}">${safeSolved}</text>
     <text x="${col1X}" y="${statsY + 20}"
       font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
       font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">Solved</text>
@@ -91,25 +98,25 @@ function renderLeetCodeCard(x, y, width, data, colors) {
       font-size="11" font-weight="600" fill="#10b981">E</text>
     <text x="${col2X + 14}" y="${statsY - 18}"
       font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
-      font-size="14" font-weight="700" fill="${colors.primaryText}">${data.easySolved ?? 0}</text>
+      font-size="14" font-weight="700" fill="${colors.primaryText}">${safeEasySolved}</text>
 
     <text x="${col2X}" y="${statsY}"
       font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
       font-size="11" font-weight="600" fill="#f59e0b">M</text>
     <text x="${col2X + 14}" y="${statsY}"
       font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
-      font-size="14" font-weight="700" fill="${colors.primaryText}">${data.mediumSolved ?? 0}</text>
+      font-size="14" font-weight="700" fill="${colors.primaryText}">${safeMediumSolved}</text>
 
     <text x="${col2X}" y="${statsY + 18}"
       font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
       font-size="11" font-weight="600" fill="#ef4444">H</text>
     <text x="${col2X + 14}" y="${statsY + 18}"
       font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
-      font-size="14" font-weight="700" fill="${colors.primaryText}">${data.hardSolved ?? 0}</text>
+      font-size="14" font-weight="700" fill="${colors.primaryText}">${safeHardSolved}</text>
 
     <text x="${col3X}" y="${statsY}"
       font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
-      font-size="32" font-weight="700" fill="${colors.primaryText}">${rating}</text>
+      font-size="32" font-weight="700" fill="${colors.primaryText}">${safeRating}</text>
     <text x="${col3X}" y="${statsY + 20}"
       font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
       font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">Rating</text>
@@ -137,12 +144,16 @@ function renderCodeforcesCard(x, y, width, data, colors) {
 
   const rankShort = rankMap[data.rank?.toLowerCase()] ?? data.rank ?? 'unrated';
   const solved = data.problemsSolved ?? 0;
+  const safeRating = sanitizeSvgValue(data.rating);
+  const safeRankShort = sanitizeSvgValue(rankShort);
+  const safeSolved = sanitizeSvgValue(solved);
+  const safeMaxRating = sanitizeSvgValue(data.maxRating);
 
   return `
     <!-- Rating -->
     <text x="${col1X}" y="${statsY}"
       font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
-      font-size="32" font-weight="700" fill="${colors.primaryText}">${data.rating}</text>
+      font-size="32" font-weight="700" fill="${colors.primaryText}">${safeRating}</text>
     <text x="${col1X}" y="${statsY + 20}"
       font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
       font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">Rating</text>
@@ -153,26 +164,24 @@ function renderCodeforcesCard(x, y, width, data, colors) {
       font-size="11" font-weight="600" fill="#6366f1">R</text>
     <text x="${col2X + 18}" y="${statsY - 18}"
       font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
-      font-size="11" font-weight="700" fill="${colors.primaryText}">${rankShort}</text>
+      font-size="11" font-weight="700" fill="${colors.primaryText}">${safeRankShort}</text>
 
     <text x="${col2X+6}" y="${statsY + 2}"
       font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
       font-size="11" font-weight="600" fill="#10b981">S</text>
     <text x="${col2X + 18}" y="${statsY + 2}"
       font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
-      font-size="11" font-weight="700" fill="${colors.primaryText}">${solved}</text>
+      font-size="11" font-weight="700" fill="${colors.primaryText}">${safeSolved}</text>
 
     <!-- Max Rating -->
     <text x="${col3X+6}" y="${statsY}"
       font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
-      font-size="32" font-weight="700" fill="${colors.primaryText}">${data.maxRating}</text>
+      font-size="32" font-weight="700" fill="${colors.primaryText}">${safeMaxRating}</text>
     <text x="${col3X}" y="${statsY + 20}"
       font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
       font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">Max Rating</text>
   `;
 }
-
-
 
 function renderCodeChefCard(x, y, width, data, colors) {
   const statsY = y + 85;
@@ -182,12 +191,16 @@ function renderCodeChefCard(x, y, width, data, colors) {
 
   const globalRank = data.globalRank ?? 'N/A';
   const division = data.division ?? 'Div 4';
+  const safeCurrentRating = sanitizeSvgValue(data.currentRating);
+  const safeStars = sanitizeSvgValue(data.stars ?? '1\u2605');
+  const safeDivision = sanitizeSvgValue(division);
+  const safeGlobalRank = sanitizeSvgValue(globalRank);
 
   return `
     <!-- Current Rating -->
     <text x="${col1X}" y="${statsY}"
       font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
-      font-size="32" font-weight="700" fill="${colors.primaryText}">${data.currentRating}</text>
+      font-size="32" font-weight="700" fill="${colors.primaryText}">${safeCurrentRating}</text>
     <text x="${col1X}" y="${statsY + 20}"
       font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
       font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">Rating</text>
@@ -195,7 +208,7 @@ function renderCodeChefCard(x, y, width, data, colors) {
     <!-- Stars -->
     <text x="${col2X + 10}" y="${statsY - 8}"
       font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
-      font-size="22" font-weight="700" fill="#f59e0b">${data.stars ?? '1★'}</text>
+      font-size="22" font-weight="700" fill="#f59e0b">${safeStars}</text>
     <text x="${col2X + 10}" y="${statsY + 10}"
       font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
       font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">Stars</text>
@@ -205,12 +218,12 @@ function renderCodeChefCard(x, y, width, data, colors) {
       fill="#8b5cf6" opacity="0.18"/>
     <text x="${col2X + 28}" y="${statsY + 29}"
       font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
-      font-size="10" font-weight="600" fill="#a78bfa" text-anchor="middle">${division}</text>
+      font-size="10" font-weight="600" fill="#a78bfa" text-anchor="middle">${safeDivision}</text>
 
     <!-- Global Rank -->
     <text x="${col3X}" y="${statsY - 8}"
       font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
-      font-size="24" font-weight="700" fill="${colors.primaryText}">${globalRank}</text>
+      font-size="24" font-weight="700" fill="${colors.primaryText}">${safeGlobalRank}</text>
     <text x="${col3X}" y="${statsY + 10}"
       font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
       font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">Global Rank</text>

--- a/src/renderers/svg.renderer.js
+++ b/src/renderers/svg.renderer.js
@@ -36,6 +36,7 @@ import oceanicNextTheme from '../themes/oceanicnext.theme.js';
 import emberGlowTheme from '../themes/emberglow.theme.js';
 import midnightNeonTheme from '../themes/midnightneon.theme.js';
 import pastelDreamTheme from '../themes/pasteldream.theme.js';
+import { sanitizeSvgValue, sanitizeSvgHref } from '../utils/svg-sanitizer.js';
 
 const LAYOUT = {
   width: 960,
@@ -162,6 +163,7 @@ export function renderBackground(width, height) {
 export function renderCard({ x, y, width, height, title, glowColor }) {
   const { colors } = currentTheme;
   const glow = glowColor || colors.glow;
+  const safeTitle = sanitizeSvgValue(String(title).toUpperCase());
 
   return `
   <g>
@@ -178,7 +180,7 @@ export function renderCard({ x, y, width, height, title, glowColor }) {
     <rect x="${x + 0.5}" y="${y + 0.5}" width="${width - 1}" height="${height - 1}" rx="${LAYOUT.cardRadius}" ry="${LAYOUT.cardRadius}" fill="none" stroke="${colors.borderLight}" stroke-width="1" opacity="0.5"/>
     
     <!-- title -->
-    <text x="${x + 20}" y="${y + 28}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="600" fill="${colors.secondaryText}" letter-spacing="0.5">${title.toUpperCase()}</text>
+    <text x="${x + 20}" y="${y + 28}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="600" fill="${colors.secondaryText}" letter-spacing="0.5">${safeTitle}</text>
     
     <!-- title underline accent -->
     <rect x="${x + 20}" y="${y + 36}" width="32" height="2" rx="1" fill="url(#accentGradient)" opacity="0.6"/>
@@ -192,6 +194,8 @@ export function renderStatItem({ x, y, label, value, icon, accentColor, showProg
 
   // dynamic font size based on value length
   const valueStr = String(value);
+  const safeValue = sanitizeSvgValue(valueStr);
+  const safeLabel = sanitizeSvgValue(String(label));
   let fontSize = 32;
   if (valueStr.length > 8) fontSize = 14;
   else if (valueStr.length > 6) fontSize = 18;
@@ -219,8 +223,8 @@ export function renderStatItem({ x, y, label, value, icon, accentColor, showProg
   return `
   <g>
     ${iconElement}
-    <text x="${x}" y="${y}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="${fontSize}" font-weight="700" fill="${colors.primaryText}" ${valueStr.length > 10 ? 'textLength="90" lengthAdjust="spacingAndGlyphs"' : ''}>${value}</text>
-    <text x="${x}" y="${y + 20}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">${label}</text>
+    <text x="${x}" y="${y}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="${fontSize}" font-weight="700" fill="${colors.primaryText}" ${valueStr.length > 10 ? 'textLength="90" lengthAdjust="spacingAndGlyphs"' : ''}>${safeValue}</text>
+    <text x="${x}" y="${y + 20}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">${safeLabel}</text>
     ${progressBar}
   </g>`;
 }
@@ -228,6 +232,9 @@ export function renderStatItem({ x, y, label, value, icon, accentColor, showProg
 // renders vertical E/M/H stat
 function renderVerticalEMH({ x, y, easy, medium, hard, accentColor }) {
   const { colors } = currentTheme;
+  const safeEasy = sanitizeSvgValue(easy);
+  const safeMedium = sanitizeSvgValue(medium);
+  const safeHard = sanitizeSvgValue(hard);
 
   const easyColor = '#10b981';  // green
   const medColor = '#f59e0b';   // amber
@@ -240,15 +247,15 @@ function renderVerticalEMH({ x, y, easy, medium, hard, accentColor }) {
   <g>
     <!-- easy -->
     <text x="${x}" y="${y - 18}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="${easyColor}">E</text>
-    <text x="${x + labelWidth}" y="${y - 18}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="${colors.primaryText}">${easy}</text>
+    <text x="${x + labelWidth}" y="${y - 18}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="${colors.primaryText}">${safeEasy}</text>
     
     <!-- medium -->
     <text x="${x}" y="${y}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="${medColor}">M</text>
-    <text x="${x + labelWidth}" y="${y}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="${colors.primaryText}">${medium}</text>
+    <text x="${x + labelWidth}" y="${y}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="${colors.primaryText}">${safeMedium}</text>
     
     <!-- hard -->
     <text x="${x}" y="${y + 18}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="600" fill="${hardColor}">H</text>
-    <text x="${x + labelWidth}" y="${y + 18}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="${colors.primaryText}">${hard}</text>
+    <text x="${x + labelWidth}" y="${y + 18}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="14" font-weight="700" fill="${colors.primaryText}">${safeHard}</text>
   </g>`;
 }
 
@@ -258,6 +265,7 @@ export function renderCardWithStats({ x, y, width, height, title, stats, cardAcc
   const glow = cardAccent || colors.glow;
   const statsStartY = y + 85;
   const statSpacing = (width - 40) / stats.length;
+  const safeTitle = sanitizeSvgValue(String(title).toUpperCase());
 
   const statsContent = stats.map((stat, index) => {
     const statX = x + 20 + (index * statSpacing);
@@ -302,7 +310,7 @@ export function renderCardWithStats({ x, y, width, height, title, stats, cardAcc
     <rect x="${x + 0.5}" y="${y + 0.5}" width="${width - 1}" height="${height - 1}" rx="${LAYOUT.cardRadius}" ry="${LAYOUT.cardRadius}" fill="none" stroke="${colors.borderLight}" stroke-width="1" opacity="0.4"/>
     
     <!-- title -->
-    <text x="${x + 20}" y="${y + 30}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="600" fill="${colors.secondaryText}" letter-spacing="0.5">${title.toUpperCase()}</text>
+    <text x="${x + 20}" y="${y + 30}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="600" fill="${colors.secondaryText}" letter-spacing="0.5">${safeTitle}</text>
     
     <!-- title accent line -->
     <rect x="${x + 20}" y="${y + 40}" width="28" height="2" rx="1" fill="url(#accentGradient)" opacity="0.7"/>
@@ -314,6 +322,10 @@ export function renderCardWithStats({ x, y, width, height, title, stats, cardAcc
 // render header section with branding
 export function renderHeader({ x, y, title, subtitle, avatarUrl, align = 'left' }) {
   const { colors } = currentTheme;
+  const titleText = String(title ?? '');
+  const safeTitle = sanitizeSvgValue(titleText);
+  const safeSubtitle = subtitle ? sanitizeSvgValue(subtitle) : '';
+  const safeAvatarUrl = sanitizeSvgHref(avatarUrl);
 
   // calculate positions based on alignment
   let avatarX, titleX, titleAnchor, subtitleAnchor;
@@ -323,30 +335,30 @@ export function renderHeader({ x, y, title, subtitle, avatarUrl, align = 'left' 
 
   if (align === 'center') {
     // center alignment
-    const titleWidth = title.length * 13;
-    const totalWidth = avatarUrl ? avatarSize + 16 + titleWidth : titleWidth;
+    const titleWidth = titleText.length * 13;
+    const totalWidth = safeAvatarUrl ? avatarSize + 16 + titleWidth : titleWidth;
     const startX = x + (contentWidth - totalWidth) / 2;
 
     avatarX = startX;
-    titleX = avatarUrl ? startX + avatarSize + 16 : startX + totalWidth / 2;
-    titleAnchor = avatarUrl ? 'start' : 'middle';
-    subtitleAnchor = avatarUrl ? 'start' : 'middle';
+    titleX = safeAvatarUrl ? startX + avatarSize + 16 : startX + totalWidth / 2;
+    titleAnchor = safeAvatarUrl ? 'start' : 'middle';
+    subtitleAnchor = safeAvatarUrl ? 'start' : 'middle';
   } else if (align === 'right') {
     // right alignment
     avatarX = x + contentWidth - avatarSize;
-    titleX = avatarUrl ? avatarX - 16 : x + contentWidth;
+    titleX = safeAvatarUrl ? avatarX - 16 : x + contentWidth;
     titleAnchor = 'end';
     subtitleAnchor = 'end';
   } else {
     // left alignment
     avatarX = x;
-    titleX = avatarUrl ? x + avatarSize + 16 : x;
+    titleX = safeAvatarUrl ? x + avatarSize + 16 : x;
     titleAnchor = 'start';
     subtitleAnchor = 'start';
   }
 
   let avatarElement = '';
-  if (avatarUrl) {
+  if (safeAvatarUrl) {
     const avatarCenterX = avatarX + avatarRadius;
     const avatarCenterY = y - 8;
     avatarElement = `
@@ -354,7 +366,7 @@ export function renderHeader({ x, y, title, subtitle, avatarUrl, align = 'left' 
         <circle cx="${avatarCenterX}" cy="${avatarCenterY}" r="${avatarRadius}"/>
       </clipPath>
       <circle cx="${avatarCenterX}" cy="${avatarCenterY}" r="${avatarRadius + 2}" fill="url(#accentGradient)" opacity="0.6"/>
-      <image href="${avatarUrl}" x="${avatarX}" y="${avatarCenterY - avatarRadius}" width="${avatarSize}" height="${avatarSize}" clip-path="url(#avatarClip)"/>`;
+      <image href="${safeAvatarUrl}" x="${avatarX}" y="${avatarCenterY - avatarRadius}" width="${avatarSize}" height="${avatarSize}" clip-path="url(#avatarClip)"/>`;
   }
 
   // branding position: left when align=right, right otherwise
@@ -365,8 +377,8 @@ export function renderHeader({ x, y, title, subtitle, avatarUrl, align = 'left' 
   <g>
     ${avatarElement}
     <!-- title with gradient -->
-    <text x="${titleX}" y="${y}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="26" font-weight="700" fill="url(#accentGradient)" text-anchor="${titleAnchor}">${title}</text>
-    ${subtitle ? `<text x="${titleX}" y="${y + 22}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="${colors.mutedText}" text-anchor="${subtitleAnchor}">${subtitle}</text>` : ''}
+    <text x="${titleX}" y="${y}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="26" font-weight="700" fill="url(#accentGradient)" text-anchor="${titleAnchor}">${safeTitle}</text>
+    ${safeSubtitle ? `<text x="${titleX}" y="${y + 22}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" fill="${colors.mutedText}" text-anchor="${subtitleAnchor}">${safeSubtitle}</text>` : ''}
     
     <!-- branding -->
     <text x="${brandingX}" y="${y}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="12" font-weight="500" fill="${colors.mutedText}" text-anchor="${brandingAnchor}" opacity="0.6">samdev-pulse</text>
@@ -404,6 +416,9 @@ function getTrophyTier(value, thresholds) {
 function renderTrophyBadge({ x, y, size, tier, icon, label, value, uniqueId }) {
   const { colors } = currentTheme;
   const halfSize = size / 2;
+  const safeTier = sanitizeSvgValue(tier.tier);
+  const safeLabel = sanitizeSvgValue(label);
+  const safeValue = sanitizeSvgValue(value);
 
   // hexagon points
   const hexPoints = [];
@@ -445,13 +460,13 @@ function renderTrophyBadge({ x, y, size, tier, icon, label, value, uniqueId }) {
     
     <!-- tier badge -->
     <circle cx="${x + size - 8}" cy="${y + 12}" r="10" fill="${tier.color}"/>
-    <text x="${x + size - 8}" y="${y + 16}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="800" fill="${colors.background}" text-anchor="middle">${tier.tier}</text>
+    <text x="${x + size - 8}" y="${y + 16}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" font-weight="800" fill="${colors.background}" text-anchor="middle">${safeTier}</text>
     
     <!-- label -->
-    <text x="${x + halfSize}" y="${y + size + 14}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="${colors.secondaryText}" text-anchor="middle">${label}</text>
+    <text x="${x + halfSize}" y="${y + size + 14}" font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="600" fill="${colors.secondaryText}" text-anchor="middle">${safeLabel}</text>
     
     <!-- value -->
-    <text x="${x + halfSize}" y="${y + size + 28}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="${colors.primaryText}" text-anchor="middle">${value}</text>
+    <text x="${x + halfSize}" y="${y + size + 28}" font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13" font-weight="700" fill="${colors.primaryText}" text-anchor="middle">${safeValue}</text>
   </g>`;
 }
 

--- a/src/utils/svg-sanitizer.js
+++ b/src/utils/svg-sanitizer.js
@@ -1,0 +1,24 @@
+const SAFE_IMAGE_HREF_REGEX = /^(https?:\/\/|data:image\/(?:png|jpe?g|gif|webp|svg\+xml);base64,)/i;
+const CONTROL_CHARS_REGEX = /[\u0000-\u001F\u007F]/g;
+
+export function sanitizeSvgValue(value = '') {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function sanitizeSvgAttribute(value = '') {
+  return sanitizeSvgValue(String(value).replace(CONTROL_CHARS_REGEX, ''));
+}
+
+export function sanitizeSvgHref(value = '') {
+  const normalized = String(value).trim();
+  if (!normalized || !SAFE_IMAGE_HREF_REGEX.test(normalized)) {
+    return '';
+  }
+
+  return sanitizeSvgAttribute(normalized);
+}

--- a/src/utils/svg-sanitizer.test.js
+++ b/src/utils/svg-sanitizer.test.js
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { sanitizeSvgValue, sanitizeSvgAttribute, sanitizeSvgHref } from './svg-sanitizer.js';
+
+test('sanitizeSvgValue escapes script-like content', () => {
+  const payload = '<script>alert("xss")</script>';
+  assert.equal(
+    sanitizeSvgValue(payload),
+    '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;'
+  );
+});
+
+test('sanitizeSvgValue escapes ampersands and quotes', () => {
+  const payload = `Tom & Jerry's "Show"`;
+  assert.equal(
+    sanitizeSvgValue(payload),
+    'Tom &amp; Jerry&#39;s &quot;Show&quot;'
+  );
+});
+
+test('sanitizeSvgValue handles malformed SVG/XML text safely', () => {
+  const payload = '</text><image href="javascript:alert(1)"/><text>';
+  assert.equal(
+    sanitizeSvgValue(payload),
+    '&lt;/text&gt;&lt;image href=&quot;javascript:alert(1)&quot;/&gt;&lt;text&gt;'
+  );
+});
+
+test('sanitizeSvgAttribute strips control chars and escapes entities', () => {
+  const payload = 'line 1\u0000 & "line 2"';
+  assert.equal(
+    sanitizeSvgAttribute(payload),
+    'line 1 &amp; &quot;line 2&quot;'
+  );
+});
+
+test('sanitizeSvgHref allows safe image href values', () => {
+  const safeUrl = 'https://avatars.githubusercontent.com/u/583231?v=4&size=64';
+  assert.equal(
+    sanitizeSvgHref(safeUrl),
+    'https://avatars.githubusercontent.com/u/583231?v=4&amp;size=64'
+  );
+});
+
+test('sanitizeSvgHref rejects unsafe protocols', () => {
+  assert.equal(sanitizeSvgHref('javascript:alert(1)'), '');
+});


### PR DESCRIPTION
## Description

This PR adds a centralized SVG/XML sanitization system for dynamic user/profile data rendered inside generated SVG dashboards.

### Changes Made

* Added a reusable `sanitizeSvgValue()` utility for escaping unsafe SVG/XML characters
* Escaped dynamic values rendered inside SVG text and attributes
* Applied sanitization across SVG renderers for:

  * GitHub display name
  * GitHub bio/subtitle
  * Username fallback text
  * Language labels
  * Competitive programming ranks/stats
  * Dynamic labels and error messages
* Added test cases for special SVG/XML characters
* Verified SVG rendering remains stable after sanitization

### Why This Change

Since the project generates live SVG dashboards using external user/platform data, unescaped special characters such as `<`, `>`, `&`, `"`, and `'` could break SVG structure or produce malformed rendering inside GitHub README embeds.

This PR improves:

* SVG rendering reliability
* README embedding stability
* Maintainability through centralized sanitization
* Production safety for dynamic SVG generation

### Issue

Fixes #39

### GSSoC

This PR is submitted under GSSoC'26.
