### PR TITLE
Refactor query parsing into centralized normalization layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node src/server.js",
     "dev": "node --watch src/server.js",
     "test": "node test-deployment.js",
-    "test:unit": "node --test src/utils/svg-sanitizer.test.js"
+    "test:unit": "node --test src/utils/svg-sanitizer.test.js src/utils/query-validation.test.js"
   },
   "keywords": [
     "github",

--- a/src/renderers/svg.renderer.js
+++ b/src/renderers/svg.renderer.js
@@ -61,14 +61,16 @@ const themes = {
   aurora: auroraTheme,
   'midnight-sunset': midnightSunsetTheme,
   onedarkpro: oneDarkProTheme,
-material: materialTheme,
-synthwave84: synthwave84Theme,
-forestnight: forestNightTheme,
-oceanicnext: oceanicNextTheme,
-emberglow: emberGlowTheme,
-midnightneon: midnightNeonTheme,
-pasteldream: pastelDreamTheme,
+  material: materialTheme,
+  synthwave84: synthwave84Theme,
+  forestnight: forestNightTheme,
+  oceanicnext: oceanicNextTheme,
+  emberglow: emberGlowTheme,
+  midnightneon: midnightNeonTheme,
+  pasteldream: pastelDreamTheme,
 };
+
+export const SUPPORTED_THEME_NAMES = Object.freeze(Object.keys(themes));
 
 // current active theme
 let currentTheme = darkTheme;
@@ -570,4 +572,3 @@ ${content}
 }
 
 export { LAYOUT };
-

--- a/src/routes/profile.route.js
+++ b/src/routes/profile.route.js
@@ -22,6 +22,7 @@ import { sendLoadingSpinner } from '../renderers/loading.renderer.js';
 import { GitHubErrorCode } from '../services/github.service.js';
 import { logApiAccess } from '../utils/logger.js';
 import { CF_RANK_MAP } from '../constants.js';
+import { normalizeProfileQuery, normalizeTheme } from '../utils/query-validation.js';
 
 const router = Router();
 
@@ -50,31 +51,27 @@ router.get('/', async (req, res) => {
   try {
   logApiAccess(req).catch(err => console.error('Log failed:', err.message));
 
-  const { theme, leetcode, align, hide_trophies, codeforces, codechef } = req.query;
-  setTheme(theme || 'dark');
+  const {
+    theme,
+    align,
+    hideTrophies,
+    username,
+    isUsernameValid,
+    leetcode,
+    codeforces,
+    codechef,
+    shouldRenderLeetCode,
+  } = normalizeProfileQuery(req.query, { defaultUsername: DEFAULT_USERNAME });
+  setTheme(theme);
 
-  const rawUsername = typeof req.query.username === 'string' ? req.query.username : '';
-  const usernameRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$|^[a-zA-Z0-9]$/;
-
-  let username;
-  if (!rawUsername) {
-    username = DEFAULT_USERNAME;
-  } else if (!usernameRegex.test(rawUsername)) {
+  if (!isUsernameValid) {
     return sendGracefulErrorSvg(res, {
       code: 'INVALID_USERNAME',
-      username: rawUsername,
+      username,
     });
-  } else {
-    username = rawUsername;
   }
 
-  const leetcodeDisabled = leetcode === 'false';
-  const shouldRenderLeetCode = Boolean(leetcode && !leetcodeDisabled);
   let showRepositoryStats = !shouldRenderLeetCode;
-  const hideTrophies = hide_trophies === 'true';
-
-  const validAlignments = ['left', 'center', 'right'];
-  const headerAlign = validAlignments.includes(align) ? align : 'left';
 
   const result = await getGitHubUserData(username);
   if (!result.success) {
@@ -236,7 +233,7 @@ router.get('/', async (req, res) => {
       title: `${data.name || username}'s Dashboard`,
       subtitle: data.bio ? (data.bio.length > 60 ? data.bio.slice(0, 60) + '...' : data.bio) : `@${username}`,
       avatarUrl: data.avatarDataUri || data.avatarUrl,
-      align: headerAlign,
+      align,
     }),
 
     renderCardWithStats({ x: calculateCardX(0, cardWidth), y: row1Y, width: cardWidth, height: cardHeight, title: card1Title, stats: card1Stats }),
@@ -285,8 +282,7 @@ router.get('/', async (req, res) => {
 
 // Loading spinner endpoint
 router.get('/loading', (req, res) => {
-  const { theme } = req.query;
-  setTheme(theme || 'dark');
+  setTheme(normalizeTheme(req.query.theme));
   return sendLoadingSpinner(res);
 });
 

--- a/src/services/codechef.service.js
+++ b/src/services/codechef.service.js
@@ -7,8 +7,9 @@ function getDivision(rating) {
 
 export async function getCodeChefData(handle) {
   try {
+    const safeHandle = encodeURIComponent(handle);
     const res = await fetch(
-      `https://competeapi.vercel.app/user/codechef/${handle}/`
+      `https://competeapi.vercel.app/user/codechef/${safeHandle}/`
     );
     const data = await res.json();
 

--- a/src/services/codeforces.service.js
+++ b/src/services/codeforces.service.js
@@ -1,8 +1,9 @@
 export async function getCodeforcesData(handle) {
   try {
+    const safeHandle = encodeURIComponent(handle);
     const [infoRes, statusRes] = await Promise.all([
-      fetch(`https://codeforces.com/api/user.info?handles=${handle}`),
-      fetch(`https://codeforces.com/api/user.status?handle=${handle}&from=1&count=10000`),
+      fetch(`https://codeforces.com/api/user.info?handles=${safeHandle}`),
+      fetch(`https://codeforces.com/api/user.status?handle=${safeHandle}&from=1&count=10000`),
     ]);
 
     const infoData = await infoRes.json();

--- a/src/utils/query-validation.js
+++ b/src/utils/query-validation.js
@@ -1,0 +1,83 @@
+import { SUPPORTED_THEME_NAMES } from '../renderers/svg.renderer.js';
+
+const DEFAULT_THEME = 'dark';
+const DEFAULT_ALIGN = 'left';
+const ALIGNMENTS = Object.freeze(['left', 'center', 'right']);
+const TRUE_VALUES = Object.freeze(['true', '1', 'yes']);
+const FALSE_VALUES = Object.freeze(['false', '0', 'no']);
+const GITHUB_USERNAME_REGEX = /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$|^[a-zA-Z0-9]$/;
+const HANDLE_SAFE_CHARS_REGEX = /[^a-zA-Z0-9_.-]/g;
+
+function firstQueryValue(value) {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+}
+
+export function normalizeString(value) {
+  const firstValue = firstQueryValue(value);
+  return typeof firstValue === 'string' ? firstValue.trim() : '';
+}
+
+export function normalizeBoolean(value, fallback = false) {
+  const normalized = normalizeString(value).toLowerCase();
+  if (TRUE_VALUES.includes(normalized)) return true;
+  if (FALSE_VALUES.includes(normalized)) return false;
+  return fallback;
+}
+
+export function normalizeTheme(value) {
+  const theme = normalizeString(value).toLowerCase();
+  return SUPPORTED_THEME_NAMES.includes(theme) ? theme : DEFAULT_THEME;
+}
+
+export function normalizeAlign(value) {
+  const align = normalizeString(value).toLowerCase();
+  return ALIGNMENTS.includes(align) ? align : DEFAULT_ALIGN;
+}
+
+export function normalizeGitHubUsername(value, defaultUsername) {
+  const username = normalizeString(value);
+  if (!username) {
+    return { username: defaultUsername, isValid: true };
+  }
+
+  return {
+    username,
+    isValid: GITHUB_USERNAME_REGEX.test(username),
+  };
+}
+
+export function normalizeCPHandle(value) {
+  const rawHandle = normalizeString(value);
+  if (!rawHandle || normalizeBoolean(rawHandle, null) !== null) {
+    return null;
+  }
+
+  const handle = rawHandle
+    .replace(/^@+/, '')
+    .replace(HANDLE_SAFE_CHARS_REGEX, '')
+    .slice(0, 64);
+
+  return handle || null;
+}
+
+export function normalizeProfileQuery(query, { defaultUsername }) {
+  const usernameResult = normalizeGitHubUsername(query.username, defaultUsername);
+  const leetcode = normalizeCPHandle(query.leetcode);
+  const codeforces = normalizeCPHandle(query.codeforces);
+  const codechef = normalizeCPHandle(query.codechef);
+
+  return {
+    theme: normalizeTheme(query.theme),
+    align: normalizeAlign(query.align),
+    hideTrophies: normalizeBoolean(query.hide_trophies, false),
+    username: usernameResult.username,
+    isUsernameValid: usernameResult.isValid,
+    leetcode,
+    codeforces,
+    codechef,
+    shouldRenderLeetCode: Boolean(leetcode),
+  };
+}

--- a/src/utils/query-validation.test.js
+++ b/src/utils/query-validation.test.js
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  normalizeAlign,
+  normalizeBoolean,
+  normalizeCPHandle,
+  normalizeGitHubUsername,
+  normalizeProfileQuery,
+  normalizeTheme,
+} from './query-validation.js';
+
+test('normalizeBoolean supports common true and false query values', () => {
+  assert.equal(normalizeBoolean(' true '), true);
+  assert.equal(normalizeBoolean('1'), true);
+  assert.equal(normalizeBoolean('YES'), true);
+  assert.equal(normalizeBoolean(' false '), false);
+  assert.equal(normalizeBoolean('0'), false);
+  assert.equal(normalizeBoolean('NO'), false);
+});
+
+test('normalizeTheme and normalizeAlign trim, lowercase, and fall back safely', () => {
+  assert.equal(normalizeTheme(' TokyoNight '), 'tokyonight');
+  assert.equal(normalizeTheme('unknown-theme'), 'dark');
+  assert.equal(normalizeAlign(' CENTER '), 'center');
+  assert.equal(normalizeAlign('middle'), 'left');
+});
+
+test('normalizeGitHubUsername trims values and preserves invalid username handling', () => {
+  assert.deepEqual(
+    normalizeGitHubUsername(' octocat ', 'SamXop123'),
+    { username: 'octocat', isValid: true }
+  );
+  assert.deepEqual(
+    normalizeGitHubUsername('bad/name', 'SamXop123'),
+    { username: 'bad/name', isValid: false }
+  );
+  assert.deepEqual(
+    normalizeGitHubUsername('', 'SamXop123'),
+    { username: 'SamXop123', isValid: true }
+  );
+});
+
+test('normalizeCPHandle sanitizes handles and treats boolean-like values as disabled', () => {
+  assert.equal(normalizeCPHandle(' @tourist '), 'tourist');
+  assert.equal(normalizeCPHandle('user/name?<x>'), 'usernamex');
+  assert.equal(normalizeCPHandle('false'), null);
+  assert.equal(normalizeCPHandle('0'), null);
+  assert.equal(normalizeCPHandle('yes'), null);
+});
+
+test('normalizeProfileQuery returns normalized values for the profile route', () => {
+  assert.deepEqual(
+    normalizeProfileQuery(
+      {
+        username: ' octocat ',
+        theme: ' Dracula ',
+        align: 'RIGHT',
+        hide_trophies: 'yes',
+        leetcode: 'false',
+        codeforces: ' tourist ',
+        codechef: '@chef-user',
+      },
+      { defaultUsername: 'SamXop123' }
+    ),
+    {
+      theme: 'dracula',
+      align: 'right',
+      hideTrophies: true,
+      username: 'octocat',
+      isUsernameValid: true,
+      leetcode: null,
+      codeforces: 'tourist',
+      codechef: 'chef-user',
+      shouldRenderLeetCode: false,
+    }
+  );
+});


### PR DESCRIPTION
## Summary

Implemented a lightweight centralized query normalization layer for `/api/profile`.

### Changes Made

* Added `query-validation.js` for centralized normalization of:

  * `theme`
  * `align`
  * boolean params
  * GitHub username
  * CP handles
* Updated `profile.route.js` to use normalized values before passing data to services/renderers
* Exposed supported theme names from `svg.renderer.js` to avoid duplicated theme constants
* Added URL encoding for Codeforces and CodeChef handles at service boundaries
* Added focused unit tests for normalization helpers and fallback behavior
* Updated `test:unit` to include the new tests

### Verification

* `npm.cmd run test:unit` → passing (11/11)
* `node --check` → passing for modified files
* `git diff --check` → clean (except standard Windows CRLF warnings)

Closes #62 