### PR TITLE
fix: add upper-bound to repo pagination to prevent timeout for 500+ repo users

### DIFF
--- a/src/services/github.service.js
+++ b/src/services/github.service.js
@@ -81,8 +81,9 @@ async function fetchUserRepos(username) {
   const repos = [];
   let page = 1;
   const perPage = 100;
+  const MAX_PAGES = 3;
 
-  while (true) {
+  while (page <= MAX_PAGES) {
     const response = await fetch(
       `${GITHUB_API_BASE}/users/${username}/repos?per_page=${perPage}&page=${page}&sort=updated`,
       { headers: getHeaders() }


### PR DESCRIPTION
## Description

`fetchUserRepos()` in github.service.js loops through all pages of a user's repositories with no maximum cap (`while true`). For users with 500+ public repos, this triggers 5+ sequential API calls, risking Vercel's 10-second serverless function timeout.

## Changes

**`src/services/github.service.js`** — Added `MAX_PAGES = 3` constant and changed `while (true)` to `while (page <= MAX_PAGES)`. The existing `data.length < perPage` early exit still works for users with fewer than 300 repos. 3 pages at 100 per page = 300 repos, which is more than enough for language stats and star counts.

## Testing
npm run test:unit

✔ sanitizeSvgValue escapes script-like content
✔ sanitizeSvgValue escapes ampersands and quotes
✔ sanitizeSvgValue handles malformed SVG/XML text safely
✔ sanitizeSvgAttribute strips control chars and escapes entities
✔ sanitizeSvgHref allows safe image href values
✔ sanitizeSvgHref rejects unsafe protocols
ℹ tests 6
ℹ suites 0
ℹ pass 6
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
## Related Issue

Closes #79