### PR TITLE
fix: show startup warning for missing GITHUB_TOKEN in production

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -27,7 +27,7 @@ function validateEnv() {
     warnings.push('GITHUB_TOKEN not set - streak stats will be unavailable');
   }
 
-  if (!IS_PRODUCTION && warnings.length > 0) {
+  if (warnings.length > 0) {
     warnings.forEach(w => console.warn(`⚠️  ${w}`));
   }
 }


### PR DESCRIPTION
### Description

The `validateEnv()` function in `src/server.js` suppressed all startup warnings in production mode (`NODE_ENV=production`). This meant if `GITHUB_TOKEN` was not set, the app ran silently with only 60 unauthenticated API requests per hour instead of 5000 — users saw mysterious rate-limit errors with zero server-side diagnostics.

### Change

Removed the `!IS_PRODUCTION` guard so critical environment warnings always display at startup, regardless of environment.

### Before

```js
if (!IS_PRODUCTION && warnings.length > 0) {
```
### After

```js
if (warnings.length > 0) {
```

### Testing

- Ran `npm test` — all existing tests pass (3 pre-existing failures unrelated to this change)
- Tested manually: warning prints in both development and production when `GITHUB_TOKEN` is missing
- Tested manually: no warning prints when `GITHUB_TOKEN` is set

Closes #103