### PR TITLE
fix: convert query-validation.test.js and svg-sanitizer.test.js to Jest

### DIFF
--- a/src/utils/query-validation.test.js
+++ b/src/utils/query-validation.test.js
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert/strict';
+import { describe, test, expect } from '@jest/globals';
 import {
   normalizeAlign,
   normalizeBoolean,
@@ -9,66 +8,67 @@ import {
   normalizeTheme,
 } from './query-validation.js';
 
-test('normalizeBoolean supports common true and false query values', () => {
-  assert.equal(normalizeBoolean(' true '), true);
-  assert.equal(normalizeBoolean('1'), true);
-  assert.equal(normalizeBoolean('YES'), true);
-  assert.equal(normalizeBoolean(' false '), false);
-  assert.equal(normalizeBoolean('0'), false);
-  assert.equal(normalizeBoolean('NO'), false);
-});
+describe('query-validation.js', () => {
+  test('normalizeBoolean supports common true and false query values', () => {
+    expect(normalizeBoolean(' true ')).toBe(true);
+    expect(normalizeBoolean('1')).toBe(true);
+    expect(normalizeBoolean('YES')).toBe(true);
+    expect(normalizeBoolean(' false ')).toBe(false);
+    expect(normalizeBoolean('0')).toBe(false);
+    expect(normalizeBoolean('NO')).toBe(false);
+  });
 
-test('normalizeTheme and normalizeAlign trim, lowercase, and fall back safely', () => {
-  assert.equal(normalizeTheme(' TokyoNight '), 'tokyonight');
-  assert.equal(normalizeTheme('unknown-theme'), 'dark');
-  assert.equal(normalizeAlign(' CENTER '), 'center');
-  assert.equal(normalizeAlign('middle'), 'left');
-});
+  test('normalizeTheme and normalizeAlign trim, lowercase, and fall back safely', () => {
+    expect(normalizeTheme(' TokyoNight ')).toBe('tokyonight');
+    expect(normalizeTheme('unknown-theme')).toBe('dark');
+    expect(normalizeAlign(' CENTER ')).toBe('center');
+    expect(normalizeAlign('middle')).toBe('left');
+  });
 
-test('normalizeGitHubUsername validates usernames correctly (lookahead rules, hyphens, and lengths)', () => {
-  // Valid usernames
-  assert.deepEqual(normalizeGitHubUsername(' octocat ', 'SamXop123'), { username: 'octocat', isValid: true });
-  assert.deepEqual(normalizeGitHubUsername('a-b', 'SamXop123'), { username: 'a-b', isValid: true });
-  assert.deepEqual(normalizeGitHubUsername('abc-def-ghi', 'SamXop123'), { username: 'abc-def-ghi', isValid: true });
-  assert.deepEqual(normalizeGitHubUsername('a', 'SamXop123'), { username: 'a', isValid: true });
-  assert.deepEqual(normalizeGitHubUsername('1', 'SamXop123'), { username: '1', isValid: true });
-  assert.deepEqual(normalizeGitHubUsername('a'.repeat(39), 'SamXop123'), { username: 'a'.repeat(39), isValid: true });
-  
-  // Empty values use fallback default
-  assert.deepEqual(normalizeGitHubUsername('', 'SamXop123'), { username: 'SamXop123', isValid: true });
+  test('normalizeGitHubUsername validates usernames correctly (lookahead rules, hyphens, and lengths)', () => {
+    // Valid usernames
+    expect(normalizeGitHubUsername(' octocat ', 'SamXop123')).toEqual({ username: 'octocat', isValid: true });
+    expect(normalizeGitHubUsername('a-b', 'SamXop123')).toEqual({ username: 'a-b', isValid: true });
+    expect(normalizeGitHubUsername('abc-def-ghi', 'SamXop123')).toEqual({ username: 'abc-def-ghi', isValid: true });
+    expect(normalizeGitHubUsername('a', 'SamXop123')).toEqual({ username: 'a', isValid: true });
+    expect(normalizeGitHubUsername('1', 'SamXop123')).toEqual({ username: '1', isValid: true });
+    expect(normalizeGitHubUsername('a'.repeat(39), 'SamXop123')).toEqual({ username: 'a'.repeat(39), isValid: true });
 
-  // Invalid usernames
-  assert.deepEqual(normalizeGitHubUsername('bad/name', 'SamXop123'), { username: 'bad/name', isValid: false });
-  assert.deepEqual(normalizeGitHubUsername('a--b', 'SamXop123'), { username: 'a--b', isValid: false });
-  assert.deepEqual(normalizeGitHubUsername('a---b', 'SamXop123'), { username: 'a---b', isValid: false });
-  assert.deepEqual(normalizeGitHubUsername('-ab', 'SamXop123'), { username: '-ab', isValid: false });
-  assert.deepEqual(normalizeGitHubUsername('ab-', 'SamXop123'), { username: 'ab-', isValid: false });
-  assert.deepEqual(normalizeGitHubUsername('a'.repeat(40), 'SamXop123'), { username: 'a'.repeat(40), isValid: false });
-});
+    // Empty values use fallback default
+    expect(normalizeGitHubUsername('', 'SamXop123')).toEqual({ username: 'SamXop123', isValid: true });
 
-test('normalizeCPHandle sanitizes handles and treats boolean-like values as disabled', () => {
-  assert.equal(normalizeCPHandle(' @tourist '), 'tourist');
-  assert.equal(normalizeCPHandle('user/name?<x>'), 'usernamex');
-  assert.equal(normalizeCPHandle('false'), null);
-  assert.equal(normalizeCPHandle('0'), null);
-  assert.equal(normalizeCPHandle('yes'), null);
-});
+    // Invalid usernames
+    expect(normalizeGitHubUsername('bad/name', 'SamXop123')).toEqual({ username: 'bad/name', isValid: false });
+    expect(normalizeGitHubUsername('a--b', 'SamXop123')).toEqual({ username: 'a--b', isValid: false });
+    expect(normalizeGitHubUsername('a---b', 'SamXop123')).toEqual({ username: 'a---b', isValid: false });
+    expect(normalizeGitHubUsername('-ab', 'SamXop123')).toEqual({ username: '-ab', isValid: false });
+    expect(normalizeGitHubUsername('ab-', 'SamXop123')).toEqual({ username: 'ab-', isValid: false });
+    expect(normalizeGitHubUsername('a'.repeat(40), 'SamXop123')).toEqual({ username: 'a'.repeat(40), isValid: false });
+  });
 
-test('normalizeProfileQuery returns normalized values for the profile route', () => {
-  assert.deepEqual(
-    normalizeProfileQuery(
-      {
-        username: ' octocat ',
-        theme: ' Dracula ',
-        align: 'RIGHT',
-        hide_trophies: 'yes',
-        leetcode: 'false',
-        codeforces: ' tourist ',
-        codechef: '@chef-user',
-      },
-      { defaultUsername: 'SamXop123' }
-    ),
-    {
+  test('normalizeCPHandle sanitizes handles and treats boolean-like values as disabled', () => {
+    expect(normalizeCPHandle(' @tourist ')).toBe('tourist');
+    expect(normalizeCPHandle('user/name?<x>')).toBe('usernamex');
+    expect(normalizeCPHandle('false')).toBe(null);
+    expect(normalizeCPHandle('0')).toBe(null);
+    expect(normalizeCPHandle('yes')).toBe(null);
+  });
+
+  test('normalizeProfileQuery returns normalized values for the profile route', () => {
+    expect(
+      normalizeProfileQuery(
+        {
+          username: ' octocat ',
+          theme: ' Dracula ',
+          align: 'RIGHT',
+          hide_trophies: 'yes',
+          leetcode: 'false',
+          codeforces: ' tourist ',
+          codechef: '@chef-user',
+        },
+        { defaultUsername: 'SamXop123' }
+      )
+    ).toEqual({
       theme: 'dracula',
       align: 'right',
       hideTrophies: true,
@@ -78,24 +78,24 @@ test('normalizeProfileQuery returns normalized values for the profile route', ()
       codeforces: 'tourist',
       codechef: 'chef-user',
       shouldRenderLeetCode: false,
-    }
-  );
-});
+    });
+  });
 
-test('normalizeProfileQuery rejects invalid platform handles securely', () => {
-  // Invalid leetcode injection
-  const q1 = normalizeProfileQuery({ leetcode: '<script>alert(1)</script>' }, { defaultUsername: 'SamXop123' });
-  assert.equal(q1.isUsernameValid, false);
+  test('normalizeProfileQuery rejects invalid platform handles securely', () => {
+    // Invalid leetcode injection
+    const q1 = normalizeProfileQuery({ leetcode: '<script>alert(1)</script>' }, { defaultUsername: 'SamXop123' });
+    expect(q1.isUsernameValid).toBe(false);
 
-  // Invalid codeforces handle
-  const q2 = normalizeProfileQuery({ codeforces: 'bad.user!' }, { defaultUsername: 'SamXop123' });
-  assert.equal(q2.isUsernameValid, false);
+    // Invalid codeforces handle
+    const q2 = normalizeProfileQuery({ codeforces: 'bad.user!' }, { defaultUsername: 'SamXop123' });
+    expect(q2.isUsernameValid).toBe(false);
 
-  // Overlong platform handle (41 characters)
-  const q3 = normalizeProfileQuery({ codechef: 'a'.repeat(41) }, { defaultUsername: 'SamXop123' });
-  assert.equal(q3.isUsernameValid, false);
+    // Overlong platform handle (41 characters)
+    const q3 = normalizeProfileQuery({ codechef: 'a'.repeat(41) }, { defaultUsername: 'SamXop123' });
+    expect(q3.isUsernameValid).toBe(false);
 
-  // Valid handles with letters, numbers, underscore, hyphen
-  const q4 = normalizeProfileQuery({ leetcode: 'user_1-2' }, { defaultUsername: 'SamXop123' });
-  assert.equal(q4.isUsernameValid, true);
+    // Valid handles with letters, numbers, underscore, hyphen
+    const q4 = normalizeProfileQuery({ leetcode: 'user_1-2' }, { defaultUsername: 'SamXop123' });
+    expect(q4.isUsernameValid).toBe(true);
+  });
 });

--- a/src/utils/svg-sanitizer.test.js
+++ b/src/utils/svg-sanitizer.test.js
@@ -1,47 +1,43 @@
-import test from 'node:test';
-import assert from 'node:assert/strict';
+import { describe, test, expect } from '@jest/globals';
 import { sanitizeSvgValue, sanitizeSvgAttribute, sanitizeSvgHref } from './svg-sanitizer.js';
 
-test('sanitizeSvgValue escapes script-like content', () => {
-  const payload = '<script>alert("xss")</script>';
-  assert.equal(
-    sanitizeSvgValue(payload),
-    '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;'
-  );
-});
+describe('svg-sanitizer.js', () => {
+  test('sanitizeSvgValue escapes script-like content', () => {
+    const payload = '<script>alert("xss")</script>';
+    expect(
+      sanitizeSvgValue(payload)
+    ).toBe('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;');
+  });
 
-test('sanitizeSvgValue escapes ampersands and quotes', () => {
-  const payload = `Tom & Jerry's "Show"`;
-  assert.equal(
-    sanitizeSvgValue(payload),
-    'Tom &amp; Jerry&#39;s &quot;Show&quot;'
-  );
-});
+  test('sanitizeSvgValue escapes ampersands and quotes', () => {
+    const payload = `Tom & Jerry's "Show"`;
+    expect(
+      sanitizeSvgValue(payload)
+    ).toBe('Tom &amp; Jerry&#39;s &quot;Show&quot;');
+  });
 
-test('sanitizeSvgValue handles malformed SVG/XML text safely', () => {
-  const payload = '</text><image href="javascript:alert(1)"/><text>';
-  assert.equal(
-    sanitizeSvgValue(payload),
-    '&lt;/text&gt;&lt;image href=&quot;javascript:alert(1)&quot;/&gt;&lt;text&gt;'
-  );
-});
+  test('sanitizeSvgValue handles malformed SVG/XML text safely', () => {
+    const payload = '</text><image href="javascript:alert(1)"/><text>';
+    expect(
+      sanitizeSvgValue(payload)
+    ).toBe('&lt;/text&gt;&lt;image href=&quot;javascript:alert(1)&quot;/&gt;&lt;text&gt;');
+  });
 
-test('sanitizeSvgAttribute strips control chars and escapes entities', () => {
-  const payload = 'line 1\u0000 & "line 2"';
-  assert.equal(
-    sanitizeSvgAttribute(payload),
-    'line 1 &amp; &quot;line 2&quot;'
-  );
-});
+  test('sanitizeSvgAttribute strips control chars and escapes entities', () => {
+    const payload = 'line 1\u0000 & "line 2"';
+    expect(
+      sanitizeSvgAttribute(payload)
+    ).toBe('line 1 &amp; &quot;line 2&quot;');
+  });
 
-test('sanitizeSvgHref allows safe image href values', () => {
-  const safeUrl = 'https://avatars.githubusercontent.com/u/583231?v=4&size=64';
-  assert.equal(
-    sanitizeSvgHref(safeUrl),
-    'https://avatars.githubusercontent.com/u/583231?v=4&amp;size=64'
-  );
-});
+  test('sanitizeSvgHref allows safe image href values', () => {
+    const safeUrl = 'https://avatars.githubusercontent.com/u/583231?v=4&size=64';
+    expect(
+      sanitizeSvgHref(safeUrl)
+    ).toBe('https://avatars.githubusercontent.com/u/583231?v=4&amp;size=64');
+  });
 
-test('sanitizeSvgHref rejects unsafe protocols', () => {
-  assert.equal(sanitizeSvgHref('javascript:alert(1)'), '');
+  test('sanitizeSvgHref rejects unsafe protocols', () => {
+    expect(sanitizeSvgHref('javascript:alert(1)')).toBe('');
+  });
 });


### PR DESCRIPTION
### Description

Two test files (`query-validation.test.js` and `svg-sanitizer.test.js`) used Node's built-in `node:test` module (`import test from 'node:test'` / `import assert from 'node:assert/strict'`), which caused them to fail when Jest picked them up via the `testMatch` pattern.

### Changes

- Converted `src/utils/query-validation.test.js` to Jest syntax
- Converted `src/utils/svg-sanitizer.test.js` to Jest syntax

### Conversion Summary

- `import test from 'node:test'` → `import { describe, test, expect } from '@jest/globals'`
- `import assert from 'node:assert/strict'` → removed
- `assert.equal(a, b)` → `expect(a).toBe(b)`
- `assert.deepEqual(a, b)` → `expect(a).toEqual(b)`
- All tests wrapped in `describe('module-name.js', ...)` blocks

### Testing

- 5/6 test suites pass (92/96 tests)
- The 4 pre-existing failures in `svg.renderer.test.js` are unrelated to this change
- Both converted files pass cleanly

Closes #106