### PR TITLE
Leetcode rating ranking bug resolved

### DIFF
--- a/src/renderers/cp-section.renderer.js
+++ b/src/renderers/cp-section.renderer.js
@@ -79,13 +79,23 @@ function renderLeetCodeCard(x, y, width, data, colors) {
   const col3X = x + 20 + ((width - 40) / 3) * 2;
 
   const solved = String(data.totalSolved ?? 0);
-  const rating = String(data.contestRating ?? data.ranking ?? 'N/A');
+  const hasContestRating =
+  data.contestRating !== null &&
+  data.contestRating !== undefined;
+
+const statValue = String(
+  hasContestRating
+    ? data.contestRating
+    : data.ranking ?? 'N/A'
+);
+
+const statLabel = hasContestRating ? 'Rating' : 'Rank';
   const safeSolved = sanitizeSvgValue(solved);
   const safeEasySolved = sanitizeSvgValue(data.easySolved ?? 0);
   const safeMediumSolved = sanitizeSvgValue(data.mediumSolved ?? 0);
   const safeHardSolved = sanitizeSvgValue(data.hardSolved ?? 0);
-  const safeRating = sanitizeSvgValue(rating);
-
+const safeStatValue = sanitizeSvgValue(statValue);
+const safeStatLabel = sanitizeSvgValue(statLabel);
   return `
     <text x="${col1X}" y="${statsY}"
       font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
@@ -117,10 +127,10 @@ function renderLeetCodeCard(x, y, width, data, colors) {
 
     <text x="${col3X}" y="${statsY}"
       font-family="'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
-      font-size="32" font-weight="700" fill="${colors.primaryText}">${safeRating}</text>
+      font-size="32" font-weight="700" fill="${colors.primaryText}">${safeStatValue}</text>
     <text x="${col3X}" y="${statsY + 20}"
       font-family="'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
-      font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">Rating</text>
+      font-size="11" fill="${colors.mutedText}" letter-spacing="0.3">${safeStatLabel}</text>
   `;
 }
 


### PR DESCRIPTION
## Changes Made

* Fixed incorrect LeetCode stat labeling in `cp-section.renderer.js`
* Added dynamic label handling for LeetCode contest stats
* When `contestRating` is available, the card displays:

  * `Rating`
* When `contestRating` is unavailable and fallback `ranking` is used, the card now displays:

  * `Rank`

screenshot 
 fixed page <img width="1053" height="624" alt="Screenshot 2026-05-30 004310" src="https://github.com/user-attachments/assets/7162e8cf-3c10-4306-8198-1aeb165bb591" />



## Problem

Previously, users without contest participation were seeing large global ranking values displayed under a hardcoded `Rating` label, which was misleading.

## Result

* Contest participants - correct `Rating`
* Non-participants - correct `Rank`
 
Resolved #86 



