### PR TITLE
fix(server): require ADMIN_API_KEY Bearer token on GET /api/cache/stats

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -38,7 +38,21 @@ app.get('/health', (req, res) => {
   res.json({ status: 'ok', timestamp: new Date().toISOString() });
 });
 
+// Cache stats endpoint — restricted to callers that supply the configured
+// ADMIN_API_KEY in the Authorization header (Bearer scheme). This is an
+// internal operations endpoint; exposing hit/miss/eviction counts publicly
+// leaks implementation details useful for timing attacks.
 app.get('/api/cache/stats', (req, res) => {
+  const adminKey = process.env.ADMIN_API_KEY;
+
+  if (adminKey) {
+    const authHeader = req.headers['authorization'] || '';
+    const supplied = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
+    if (supplied !== adminKey) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+  }
+
   res.json(githubCache.getStats());
 });
 


### PR DESCRIPTION
## Description

Closes #132

`GET /api/cache/stats` returned internal cache hit rates, miss counts, eviction counts, and current store size to any anonymous caller with no authentication. These metrics are internal operational data that can help an attacker time requests, infer which GitHub usernames are cached, and fingerprint the service's behaviour.

**Root cause:** the endpoint was registered without any authentication middleware.

**Fix:** Added a Bearer-token check using `process.env.ADMIN_API_KEY`. When the variable is set, any request that does not supply the correct token in an `Authorization: Bearer <key>` header receives `401 Unauthorized`. When the variable is not set, the endpoint remains accessible (backwards-compatible with deployments that have not yet configured an admin key).

## Related Issue

Closes #132

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `src/server.js`: added an `ADMIN_API_KEY` Bearer-token guard to the `GET /api/cache/stats` route.

## Screenshots / Demo

Not applicable. This is a server-side access control fix.

## Testing Done

1. Set `ADMIN_API_KEY=secret` in your environment and start the server.
2. Send `GET /api/cache/stats` with no header. Confirm `401 Unauthorized`.
3. Send with `Authorization: Bearer wrongkey`. Confirm `401`.
4. Send with `Authorization: Bearer secret`. Confirm the stats JSON is returned.
5. Unset `ADMIN_API_KEY` and restart. Confirm the endpoint is accessible without a token (backwards-compatible mode).

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue
- [x] I have not used any AI-generated content in this PR

## GSSoC Label Request

Could you please add the appropriate GSSoC 2026 label to this PR? It helps with tracking and scoring under GSSoC '26. Thank you!

program: gssoc