### PR TITLE
fix(profile): replace fake contribution fallback with zero-filled array when GitHub API is unavailable

### DIFF
--- a/src/routes/profile.route.js
+++ b/src/routes/profile.route.js
@@ -206,7 +206,12 @@ router.get('/', async (req, res) => {
     const recentDays = contributionData.days.slice(-30);
     chartData = recentDays.map(day => day.count);
   } else {
-    chartData = generateFakeContributionData(30);
+    // Do not fall back to randomly generated data when the GitHub GraphQL
+    // API is unavailable. Embedding fake contribution bars in a README
+    // misleads viewers into believing they represent real activity.
+    // Use zeroed-out bars instead so the chart is visually consistent but
+    // clearly reflects that no data is available.
+    chartData = Array(30).fill(0);
   }
 
   const topLanguages = getTopLanguages(data.repos, 5);


### PR DESCRIPTION
## Description

Closes #130

When the GitHub GraphQL service returned no contribution data, `profile.route.js` silently called `generateFakeContributionData(30)`, which produced a realistic-looking randomised bar chart. The fabricated bars are indistinguishable from real contribution activity when the card is embedded in a README. A profile owner who is unaware of this fallback may unknowingly publish a misleading contribution history.

**Root cause:** the else branch fell back to randomly generated data instead of showing an empty or neutral state.

**Fix:** Replace `generateFakeContributionData(30)` with `Array(30).fill(0)`. The chart remains visually consistent (same bar count) but clearly reflects that no data was available rather than inventing plausible-looking activity.

## Related Issue

Closes #130

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `src/routes/profile.route.js`: replaced `generateFakeContributionData(30)` with `Array(30).fill(0)` in the contribution data fallback block.

## Screenshots / Demo

Not applicable. The fix changes the fallback bar data from random positive values to zeros.

## Testing Done

1. Simulate a GitHub GraphQL unavailability by temporarily setting an invalid token or blocking the GraphQL endpoint.
2. Request a profile card (`GET /api/profile?username=some-user`).
3. Confirm the contribution chart shows flat zero bars rather than a random pattern.
4. Restore the token and confirm real contribution data renders normally.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue
- [x] I have not used any AI-generated content in this PR

## GSSoC Label Request

Could you please add the appropriate GSSoC 2026 label to this PR? It helps with tracking and scoring under GSSoC '26. Thank you!

program: gssoc