### PR TITLE
fix: prevent rendering fallback profile when username is missing

### DIFF
--- a/src/utils/query-validation.js
+++ b/src/utils/query-validation.js
@@ -40,9 +40,8 @@ export function normalizeAlign(value) {
 export function normalizeGitHubUsername(value, defaultUsername) {
   const username = normalizeString(value);
   if (!username) {
-    return { username: defaultUsername, isValid: true };
-  }
-
+  return { username: '', isValid: false };
+ }
   return {
     username,
     isValid: GITHUB_USERNAME_REGEX.test(username),

--- a/src/utils/query-validation.test.js
+++ b/src/utils/query-validation.test.js
@@ -93,19 +93,43 @@ describe('query-validation.js', () => {
 
   test('normalizeProfileQuery rejects invalid platform handles securely', () => {
     // Invalid leetcode injection
-    const q1 = normalizeProfileQuery({ leetcode: '<script>alert(1)</script>' }, { defaultUsername: 'SamXop123' });
+    const q1 = normalizeProfileQuery(
+      {
+        username: 'SamXop123',
+        leetcode: '<script>alert(1)</script>'
+      },
+      { defaultUsername: 'SamXop123' }
+    );
     expect(q1.isUsernameValid).toBe(false);
 
     // Invalid codeforces handle
-    const q2 = normalizeProfileQuery({ codeforces: 'bad.user!' }, { defaultUsername: 'SamXop123' });
+    const q2 = normalizeProfileQuery(
+      {
+        username: 'SamXop123',
+        codeforces: 'bad.user!'
+      },
+      { defaultUsername: 'SamXop123' }
+    );
     expect(q2.isUsernameValid).toBe(false);
 
     // Overlong platform handle (41 characters)
-    const q3 = normalizeProfileQuery({ codechef: 'a'.repeat(41) }, { defaultUsername: 'SamXop123' });
+    const q3 = normalizeProfileQuery(
+      {
+        username: 'SamXop123',
+        codechef: 'a'.repeat(41)
+      },
+      { defaultUsername: 'SamXop123' }
+    );
     expect(q3.isUsernameValid).toBe(false);
 
     // Valid handles with letters, numbers, underscore, hyphen
-    const q4 = normalizeProfileQuery({ leetcode: 'user_1-2' }, { defaultUsername: 'SamXop123' });
+    const q4 = normalizeProfileQuery(
+      {
+        username: 'SamXop123',
+        leetcode: 'user_1-2'
+      },
+      { defaultUsername: 'SamXop123' }
+    );
     expect(q4.isUsernameValid).toBe(true);
   });
 });

--- a/src/utils/query-validation.test.js
+++ b/src/utils/query-validation.test.js
@@ -35,7 +35,7 @@ describe('query-validation.js', () => {
     expect(normalizeGitHubUsername('a'.repeat(39), 'SamXop123')).toEqual({ username: 'a'.repeat(39), isValid: true });
 
     // Empty values use fallback default
-    expect(normalizeGitHubUsername('', 'SamXop123')).toEqual({ username: 'SamXop123', isValid: true });
+    expect(normalizeGitHubUsername('', 'SamXop123')).toEqual({ username: '', isValid: false });
 
     // Invalid usernames
     expect(normalizeGitHubUsername('bad/name', 'SamXop123')).toEqual({ username: 'bad/name', isValid: false });
@@ -79,6 +79,16 @@ describe('query-validation.js', () => {
       codechef: 'chef-user',
       shouldRenderLeetCode: false,
     });
+  });
+
+  test('normalizeProfileQuery rejects missing username', () => {
+    const result = normalizeProfileQuery(
+      {},
+      { defaultUsername: 'SamXop123' }
+    );
+
+    expect(result.isUsernameValid).toBe(false);
+    expect(result.username).toBe('');
   });
 
   test('normalizeProfileQuery rejects invalid platform handles securely', () => {


### PR DESCRIPTION
## Summary
Fixes an issue where requests without a `username` parameter would silently fall back to the configured `DEFAULT_USERNAME`, causing another user's profile to be rendered.

## Changes Made
- Removed automatic fallback behavior for missing GitHub usernames
- Missing usernames now fail validation
- Existing graceful error SVG flow is triggered instead of rendering a fallback profile
- Added test coverage for missing username scenarios

## Files Updated
- src/utils/query-validation.js
- src/utils/query-validation.test.js

## Result
Requests without a `username` parameter now return a graceful error response rather than rendering another user's GitHub profile.

Closes #133