### PR TITLE
feat: add theme comparison page with dashboard previews

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -690,7 +689,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -714,7 +712,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2017,7 +2014,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5279,7 +5275,6 @@
       "integrity": "sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "abab": "^2.0.6",
         "cssstyle": "^3.0.0",

--- a/public/index.html
+++ b/public/index.html
@@ -582,6 +582,17 @@
           <p>No themes match your search.</p>
           <small>Try a different keyword or click "All" to reset.</small>
         </div>
+
+        <!-- Theme Comparison Link -->
+        <div class="theme-comparison-cta">
+          <a href="/theme-comparison" class="btn btn-outline theme-comparison-btn">
+            View Theme Comparison
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M5 12h14M12 5l7 7-7 7" />
+            </svg>
+          </a>
+          <p class="theme-comparison-hint">Compare all themes side-by-side with full dashboard previews</p>
+        </div>
       </div>
     </div>
   </section>

--- a/public/index.html
+++ b/public/index.html
@@ -272,6 +272,17 @@
         <p class="theme-result-count" id="themeResultCount"></p>
       </div>
 
+      <!-- Theme Comparison CTA - In the middle -->
+      <div class="theme-comparison-cta">
+        <a href="/theme-comparison" class="btn btn-outline theme-comparison-btn">
+          View Theme Comparison
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M5 12h14M12 5l7 7-7 7" />
+          </svg>
+        </a>
+        <p class="theme-comparison-hint">Compare all themes side-by-side with full dashboard previews</p>
+      </div>
+
       <div class="themes-grid" id="themesGrid">
         <div class="theme-card" data-theme="" data-cat="minimal" data-colors="black purple white" tabindex="0"
           role="button" aria-label="Select Dark theme">
@@ -581,17 +592,6 @@
         <div class="theme-empty-state" id="themeEmptyState" style="display:none;">
           <p>No themes match your search.</p>
           <small>Try a different keyword or click "All" to reset.</small>
-        </div>
-
-        <!-- Theme Comparison Link -->
-        <div class="theme-comparison-cta">
-          <a href="/theme-comparison" class="btn btn-outline theme-comparison-btn">
-            View Theme Comparison
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M5 12h14M12 5l7 7-7 7" />
-            </svg>
-          </a>
-          <p class="theme-comparison-hint">Compare all themes side-by-side with full dashboard previews</p>
         </div>
       </div>
     </div>

--- a/public/index.html
+++ b/public/index.html
@@ -587,6 +587,17 @@
               <path d="M6 9l6 6 6-6" />
             </svg>
           </button>
+          <!-- Theme Comparison Link -->
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          <a href="/theme-comparison" class="btn btn-outline theme-comparison-btn">
+            View Theme Comparison
+            <p class="theme-comparison-hint">(Compare all themes side-by-side with full dashboard previews)</p>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M5 12h14M12 5l7 7-7 7" />
+            </svg>
+          </a>
+          
+        
         </div>
         <!-- Empty state shown when nothing matches -->
         <div class="theme-empty-state" id="themeEmptyState" style="display:none;">

--- a/public/index.html
+++ b/public/index.html
@@ -273,15 +273,6 @@
       </div>
 
       <!-- Theme Comparison CTA - In the middle -->
-      <div class="theme-comparison-cta">
-        <a href="/theme-comparison" class="btn btn-outline theme-comparison-btn">
-          View Theme Comparison
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="M5 12h14M12 5l7 7-7 7" />
-          </svg>
-        </a>
-        <p class="theme-comparison-hint">Compare all themes side-by-side with full dashboard previews</p>
-      </div>
 
       <div class="themes-grid" id="themesGrid">
         <div class="theme-card" data-theme="" data-cat="minimal" data-colors="black purple white" tabindex="0"
@@ -581,24 +572,27 @@
         </div>
         <!-- Show More / Show Less button -->
         <div class="theme-show-more-wrapper" id="themeShowMoreWrapper">
-          <button class="theme-show-more-btn" id="themeShowMoreBtn">
-            Show All Themes
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M6 9l6 6 6-6" />
-            </svg>
-          </button>
-          <!-- Theme Comparison Link -->
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-          <a href="/theme-comparison" class="btn btn-outline theme-comparison-btn">
-            View Theme Comparison
-            <p class="theme-comparison-hint">(Compare all themes side-by-side with full dashboard previews)</p>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M5 12h14M12 5l7 7-7 7" />
-            </svg>
-          </a>
-          
-        
-        </div>
+
+  <button class="theme-show-more-btn" id="themeShowMoreBtn">
+    Show All Themes
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M6 9l6 6 6-6" />
+    </svg>
+  </button>
+
+  <br><br>
+  &nbsp;&nbsp;&nbsp;
+
+  <a href="/theme-comparison"
+     class="theme-show-more-btn"
+     style="text-decoration: none; display: inline-flex; align-items: center;">
+    View Theme Comparison
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M5 12h14M12 5l7 7-7 7" />
+    </svg>
+  </a>
+
+</div>
         <!-- Empty state shown when nothing matches -->
         <div class="theme-empty-state" id="themeEmptyState" style="display:none;">
           <p>No themes match your search.</p>

--- a/public/styles.css
+++ b/public/styles.css
@@ -2106,3 +2106,43 @@ html {
     max-width: 260px;
   }
 }
+
+/* ===== Theme Comparison CTA ===== */
+.theme-comparison-cta {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-xl);
+  padding-top: var(--spacing-xl);
+  border-top: 1px solid var(--border);
+}
+
+.theme-comparison-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  font-size: 0.95rem;
+}
+
+.theme-comparison-btn svg {
+  transition: transform var(--transition-base);
+}
+
+.theme-comparison-btn:hover svg {
+  transform: translateX(4px);
+}
+
+.theme-comparison-hint {
+  font-size: 0.85rem;
+  color: var(--text-tertiary);
+  text-align: center;
+}
+
+@media (max-width: 768px) {
+  .theme-comparison-cta {
+    margin-top: var(--spacing-lg);
+    padding-top: var(--spacing-lg);
+  }
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -2113,9 +2113,12 @@ html {
   flex-direction: column;
   align-items: center;
   gap: var(--spacing-sm);
-  margin-top: var(--spacing-xl);
-  padding-top: var(--spacing-xl);
-  border-top: 1px solid var(--border);
+  margin: var(--spacing-xl) auto;
+  padding: var(--spacing-lg) var(--spacing-xl);
+  background: var(--bg-secondary);
+  border: 1px dashed var(--border-light);
+  border-radius: var(--radius-lg);
+  max-width: 500px;
 }
 
 .theme-comparison-btn {

--- a/public/theme-comparison.html
+++ b/public/theme-comparison.html
@@ -1,0 +1,457 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description"
+    content="Compare all available samdev-pulse themes side-by-side. Find the perfect theme for your GitHub profile README.">
+  <meta name="keywords" content="GitHub, README, themes, comparison, profile, stats">
+  <title>Theme Comparison | samdev-pulse</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/styles.css">
+  <link rel="icon" href="./logo-samdev-pulse.png">
+  <style>
+    /* Theme Comparison Page Styles */
+    .comparison-header {
+      padding: var(--spacing-3xl) 0 var(--spacing-2xl);
+      text-align: center;
+    }
+
+    .comparison-header .section-title {
+      font-size: 2.5rem;
+      margin-bottom: var(--spacing-md);
+      background: linear-gradient(135deg, #8b5cf6 0%, #3b82f6 50%, #ec4899 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .comparison-header .section-subtitle {
+      font-size: 1.125rem;
+      color: var(--text-secondary);
+      max-width: 600px;
+      margin: 0 auto var(--spacing-xl);
+    }
+
+    .back-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: var(--accent-purple);
+      text-decoration: none;
+      font-weight: 500;
+      margin-bottom: var(--spacing-lg);
+      transition: color var(--transition-base), transform var(--transition-base);
+    }
+
+    .back-link:hover {
+      color: var(--accent-blue);
+      transform: translateX(-4px);
+    }
+
+    .themes-comparison-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(480px, 1fr));
+      gap: var(--spacing-xl);
+      padding-bottom: var(--spacing-3xl);
+    }
+
+    .theme-preview-card {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-xl);
+      overflow: hidden;
+      transition: transform var(--transition-base), box-shadow var(--transition-base), border-color var(--transition-base);
+    }
+
+    .theme-preview-card:hover {
+      transform: translateY(-4px);
+      box-shadow: var(--shadow-lg);
+      border-color: var(--accent-purple);
+    }
+
+    .theme-preview-card img {
+      width: 100%;
+      height: auto;
+      display: block;
+      border-radius: var(--radius-lg);
+      margin: var(--spacing-md);
+    }
+
+    .theme-preview-footer {
+      padding: var(--spacing-md) var(--spacing-lg) var(--spacing-lg);
+      border-top: 1px solid var(--border);
+    }
+
+    .theme-preview-name {
+      font-size: 1.25rem;
+      font-weight: 600;
+      margin-bottom: var(--spacing-xs);
+    }
+
+    .theme-preview-desc {
+      font-size: 0.875rem;
+      color: var(--text-secondary);
+      margin-bottom: var(--spacing-md);
+    }
+
+    .theme-preview-code {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background: var(--bg-tertiary);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      font-family: 'Monaco', 'Menlo', monospace;
+      font-size: 0.8rem;
+      color: var(--text-secondary);
+      transition: all var(--transition-base);
+    }
+
+    .theme-preview-code:hover {
+      border-color: var(--accent-purple);
+      color: var(--text-primary);
+    }
+
+    .copy-icon {
+      width: 14px;
+      height: 14px;
+      opacity: 0.7;
+    }
+
+    .loading-placeholder {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 300px;
+      background: var(--bg-tertiary);
+      border-radius: var(--radius-lg);
+      margin: var(--spacing-md);
+    }
+
+    .loading-spinner {
+      width: 40px;
+      height: 40px;
+      border: 3px solid var(--border);
+      border-top-color: var(--accent-purple);
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+
+    @keyframes spin {
+      to {
+        transform: rotate(360deg);
+      }
+    }
+
+    @media (max-width: 768px) {
+      .themes-comparison-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .comparison-header .section-title {
+        font-size: 1.75rem;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <!-- NAVBAR -->
+  <div class="navbar">
+    <div class="navlogo">
+      <a href="https://samdev-pulse.vercel.app/">
+        <img src="./logo-samdev-pulse.png" alt="logo-samdev-pulse">
+      </a>
+    </div>
+
+    <button class="nav-hamburger" id="nav-hamburger" aria-label="Toggle navigation menu" aria-expanded="false"
+      aria-controls="nav-menu">
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>
+
+    <div class="navbtn" id="nav-menu">
+      <ul>
+        <li><a href="/" class="nav-link">HOME</a></li>
+        <li><a href="/#features" class="nav-link">FEATURES</a></li>
+        <li><a href="/#themes" class="nav-link">THEMES</a></li>
+        <li><a href="/#preview" class="nav-link">TRY IT LIVE</a></li>
+        <li><a href="/#guide" class="nav-link">GUIDE</a></li>
+      </ul>
+    </div>
+
+    <div class="nav-actions">
+      <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to light theme"
+        aria-pressed="false">
+        <svg class="theme-toggle-icon sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none"
+          stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="4"></circle>
+          <path d="M12 2v2"></path>
+          <path d="M12 20v2"></path>
+          <path d="m4.93 4.93 1.41 1.41"></path>
+          <path d="m17.66 17.66 1.41 1.41"></path>
+          <path d="M2 12h2"></path>
+          <path d="M20 12h2"></path>
+          <path d="m6.34 17.66-1.41 1.41"></path>
+          <path d="m19.07 4.93-1.41 1.41"></path>
+        </svg>
+        <svg class="theme-toggle-icon moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none"
+          stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M12 3a6 6 0 0 0 9 7.46A9 9 0 1 1 12 3Z"></path>
+        </svg>
+        <span class="sr-only">Toggle color theme</span>
+      </button>
+    </div>
+  </div>
+
+  <main class="container">
+    <a href="/" class="back-link">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M19 12H5M12 19l-7-7 7-7"/>
+      </svg>
+      Back to Home
+    </a>
+
+    <header class="comparison-header">
+      <h1 class="section-title">Theme Comparison</h1>
+      <p class="section-subtitle">
+        Explore all available themes and find the perfect one for your GitHub profile.
+        Each preview shows the same dashboard data with different color schemes.
+      </p>
+    </header>
+
+    <div class="themes-comparison-grid" id="themesGrid">
+      <!-- Theme cards will be dynamically inserted here -->
+    </div>
+  </main>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-content">
+        <div class="footer-brand">
+          <div class="footer-logo">samdev-pulse</div>
+          <p class="footer-tagline">Elevate your GitHub presence</p>
+        </div>
+        <div class="footer-links">
+          <div class="footer-column">
+            <a href="/#preview">Try Live</a>
+            <a href="https://github.com/SamXop123/samdev-pulse#readme" target="_blank" rel="noopener">Documentation</a>
+            <a href="https://github.com/SamXop123/samdev-pulse" target="_blank" rel="noopener">GitHub</a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>© 2026 samdev-pulse.</p>
+        <p>Built with ❤️ by <a href="https://github.com/SamXop123" target="_blank" rel="noopener">SamXop123</a></p>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    // Theme configuration
+    const themes = [
+      { name: 'Dark', id: 'dark', description: 'Purple accents on dark background' },
+      { name: 'Light', id: 'light', description: 'Clean white with blue accents' },
+      { name: 'Dracula', id: 'dracula', description: 'Dark mode with vibrant colors' },
+      { name: 'Nord', id: 'nord', description: 'Arctic, north-inspired colors' },
+      { name: 'Monokai', id: 'monokai', description: 'Classic code editor aesthetic' },
+      { name: 'Gruvbox', id: 'gruvbox', description: 'Retro terminal warmth' },
+      { name: 'Tokyo Night', id: 'tokyonight', description: 'Neon Tokyo night vibes' },
+      { name: 'Solarized', id: 'solarized', description: 'Precision colors for readability' },
+      { name: 'Catppuccin', id: 'catppuccin', description: 'Soothing pastel palette' },
+      { name: 'Rose Pine', id: 'rose-pine', description: 'Gentle rose and pine tones' },
+      { name: 'Aurora', id: 'aurora', description: 'Northern lights inspired' },
+      { name: 'Midnight Sunset', id: 'midnight-sunset', description: 'Warm sunset gradients' },
+      { name: 'One Dark Pro', id: 'onedarkpro', description: 'Atom One Dark theme' },
+      { name: 'Material', id: 'material', description: 'Google Material Design colors' },
+      { name: 'Synthwave 84', id: 'synthwave84', description: 'Retro synthwave aesthetic' },
+      { name: 'Forest Night', id: 'forestnight', description: 'Deep forest greens' },
+      { name: 'Oceanic Next', id: 'oceanicnext', description: 'Deep sea exploration' },
+      { name: 'Emberglow', id: 'emberglow', description: 'Warm ember and glow' },
+      { name: 'Midnight Neon', id: 'midnightneon', description: 'Neon lights at midnight' },
+      { name: 'Pastel Dream', id: 'pasteldream', description: 'Soft pastel aesthetics' },
+      { name: 'Cobalt 2', id: 'cobalt2', description: 'Bold blue Cobalt theme' },
+      { name: 'One Dark', id: 'one-dark', description: 'Clean dark theme' },
+      { name: 'GitHub Light', id: 'github-light', description: 'GitHub light mode colors' },
+    ];
+
+    const baseUrl = window.location.hostname === 'localhost'
+      ? window.location.origin
+      : 'https://samdev-pulse.vercel.app';
+
+    function generateThemeCard(theme) {
+      const previewUrl = `${baseUrl}/api/theme-preview/${theme.id}`;
+      const markdownUrl = `${baseUrl}/api/profile?username=YOUR_USERNAME&theme=${theme.id}`;
+
+      return `
+        <article class="theme-preview-card">
+          <img
+            src="${previewUrl}"
+            alt="${theme.name} theme preview"
+            loading="lazy"
+            onerror="this.parentElement.querySelector('.loading-placeholder')?.remove(); this.style.display='block';"
+          />
+          <div class="theme-preview-footer">
+            <h3 class="theme-preview-name">${theme.name}</h3>
+            <p class="theme-preview-desc">${theme.description}</p>
+            <button class="theme-preview-code" data-url="${markdownUrl}" onclick="copyToClipboard(this.dataset.url, this)">
+              <code>theme=${theme.id}</code>
+              <svg class="copy-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+              </svg>
+            </button>
+          </div>
+        </article>
+      `;
+    }
+
+    function copyToClipboard(text, button) {
+      navigator.clipboard.writeText(`![samdev-pulse](${text})`).then(() => {
+        const originalContent = button.innerHTML;
+        button.innerHTML = `
+          <code>Copied!</code>
+          <svg class="copy-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <polyline points="20 6 9 17 4 12"></polyline>
+          </svg>
+        `;
+        button.style.borderColor = '#10b981';
+        setTimeout(() => {
+          button.innerHTML = originalContent;
+          button.style.borderColor = '';
+        }, 2000);
+      });
+    }
+
+    // Initialize theme comparison grid
+    function initThemeComparison() {
+      const grid = document.getElementById('themesGrid');
+      if (!grid) return;
+
+      // Generate theme cards
+      grid.innerHTML = themes.map(generateThemeCard).join('');
+
+      // Lazy load images when they come into view
+      const imageObserver = new IntersectionObserver((entries, observer) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            const img = entry.target;
+            if (img.dataset.src) {
+              img.src = img.dataset.src;
+              observer.unobserve(img);
+            }
+          }
+        });
+      }, { rootMargin: '100px' });
+
+      grid.querySelectorAll('img[data-src]').forEach(img => {
+        imageObserver.observe(img);
+      });
+    }
+
+    // Navbar theme toggle (same as main site)
+    (function() {
+      const THEME_KEY = 'theme';
+      const LIGHT_THEME = 'light';
+
+      function getStoredTheme() {
+        try {
+          return localStorage.getItem(THEME_KEY);
+        } catch (error) {
+          return null;
+        }
+      }
+
+      function storeTheme(theme) {
+        try {
+          localStorage.setItem(THEME_KEY, theme);
+        } catch (error) {}
+      }
+
+      function applyTheme(theme) {
+        const isLight = theme === LIGHT_THEME;
+        document.body.classList.toggle('light-theme', isLight);
+
+        const toggle = document.getElementById('theme-toggle');
+        if (toggle) {
+          toggle.setAttribute('aria-pressed', String(isLight));
+          toggle.setAttribute('aria-label', isLight ? 'Switch to dark theme' : 'Switch to light theme');
+        }
+      }
+
+      function initThemeToggle() {
+        const toggle = document.getElementById('theme-toggle');
+        const savedTheme = getStoredTheme();
+        applyTheme(savedTheme === LIGHT_THEME ? LIGHT_THEME : 'dark');
+
+        if (!toggle) return;
+
+        toggle.addEventListener('click', function() {
+          const nextTheme = document.body.classList.contains('light-theme') ? 'dark' : LIGHT_THEME;
+          applyTheme(nextTheme);
+          storeTheme(nextTheme);
+        });
+      }
+
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initThemeToggle);
+      } else {
+        initThemeToggle();
+      }
+    })();
+
+    // Hamburger menu (same as main site)
+    (function() {
+      function initHamburger() {
+        const hamburger = document.getElementById('nav-hamburger');
+        const navMenu = document.getElementById('nav-menu');
+
+        if (!hamburger || !navMenu) return;
+
+        hamburger.addEventListener('click', function() {
+          const isOpen = navMenu.classList.toggle('is-open');
+          hamburger.classList.toggle('is-open', isOpen);
+          hamburger.setAttribute('aria-expanded', String(isOpen));
+        });
+
+        navMenu.querySelectorAll('a').forEach(function(link) {
+          link.addEventListener('click', function() {
+            navMenu.classList.remove('is-open');
+            hamburger.classList.remove('is-open');
+            hamburger.setAttribute('aria-expanded', 'false');
+          });
+        });
+
+        document.addEventListener('click', function(e) {
+          if (!hamburger.contains(e.target) && !navMenu.contains(e.target)) {
+            navMenu.classList.remove('is-open');
+            hamburger.classList.remove('is-open');
+            hamburger.setAttribute('aria-expanded', 'false');
+          }
+        });
+      }
+
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initHamburger);
+      } else {
+        initHamburger();
+      }
+    })();
+
+    // Initialize on DOM ready
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', initThemeComparison);
+    } else {
+      initThemeComparison();
+    }
+  </script>
+</body>
+
+</html>

--- a/src/routes/theme-comparison.route.js
+++ b/src/routes/theme-comparison.route.js
@@ -1,0 +1,213 @@
+import { Router } from 'express';
+import {
+  renderBackground,
+  renderHeader,
+  renderCardWithStats,
+  calculateCardWidth,
+  calculateCardX,
+  wrapSvg,
+  setTheme,
+  LAYOUT,
+  renderTrophyRow,
+} from '../renderers/svg.renderer.js';
+import { renderContributionChart, renderDonutChart } from '../renderers/chart.renderer.js';
+
+const router = Router();
+
+// Mock data for theme preview
+const mockData = {
+  name: 'Sam',
+  bio: 'Full Stack Developer',
+  avatarUrl: 'https://avatars.githubusercontent.com/u/169450602?v=4',
+  avatarDataUri: null,
+  publicRepos: 25,
+  totalStars: 152,
+  followers: 89,
+  repos: [
+    { language: 'JavaScript' },
+    { language: 'TypeScript' },
+    { language: 'Python' },
+    { language: 'Rust' },
+    { language: 'Go' },
+  ],
+};
+
+// Mock contribution data
+const mockContributionData = {
+  totalContributions: 1247,
+  totalPRs: 89,
+  totalIssues: 45,
+  totalReviews: 23,
+  currentStreak: 15,
+  longestStreak: 42,
+  totalContributionDays: 365,
+  days: Array.from({ length: 30 }, (_, i) => ({
+    count: Math.floor(Math.random() * 10),
+  })),
+};
+
+// Trophy data
+const mockTrophyData = {
+  commits: 1247,
+  prs: 89,
+  issues: 45,
+  repos: 25,
+  stars: 152,
+  followers: 89,
+  reviews: 23,
+};
+
+function formatNumber(num) {
+  if (num >= 1000000) return (num / 1000000).toFixed(1) + 'M';
+  if (num >= 1000) return (num / 1000).toFixed(1) + 'k';
+  return num.toString();
+}
+
+function getTopLanguages(repos, max = 5) {
+  if (!Array.isArray(repos) || repos.length === 0) {
+    return [];
+  }
+  const langCounts = {};
+  repos.forEach((repo) => {
+    const language = repo?.language;
+    if (typeof language === 'string' && language.trim()) {
+      langCounts[language] = (langCounts[language] || 0) + 1;
+    }
+  });
+  return Object.entries(langCounts)
+    .map(([label, value]) => ({ label, value }))
+    .sort((a, b) => b.value - a.value)
+    .slice(0, max);
+}
+
+// Render a mini dashboard preview for a specific theme
+router.get('/:themeName', (req, res) => {
+  try {
+    const { themeName } = req.params;
+
+    setTheme(themeName);
+
+    const width = LAYOUT.width;
+    const cardWidth = calculateCardWidth(3);
+    const cardHeight = 140;
+    const row1Y = 95;
+
+    const row2Y = row1Y + cardHeight + LAYOUT.cardGap;
+    const chartWidth = calculateCardWidth(2) + LAYOUT.cardGap / 2;
+    const row2CardWidth = calculateCardWidth(2) - LAYOUT.cardGap / 2;
+    const row2Height = 200;
+
+    const fullWidth = width - (LAYOUT.padding * 2);
+
+    const card1Title = 'GitHub Activity';
+    const card1Stats = [
+      { label: 'Contributions', value: formatNumber(mockContributionData.totalContributions) },
+      { label: 'PRs Opened', value: formatNumber(mockContributionData.totalPRs) },
+      { label: 'Issues Opened', value: formatNumber(mockContributionData.totalIssues) },
+    ];
+
+    const streakStats = [
+      { label: 'Current', value: formatNumber(mockContributionData.currentStreak) },
+      { label: 'Longest', value: formatNumber(mockContributionData.longestStreak) },
+      { label: 'Total', value: formatNumber(mockContributionData.totalContributionDays) },
+    ];
+
+    const card3Title = 'Repository Stats';
+    const card3Stats = [
+      { label: 'Repositories', value: formatNumber(mockData.publicRepos) },
+      { label: 'Stars', value: formatNumber(mockData.totalStars) },
+      { label: 'Followers', value: formatNumber(mockData.followers) },
+    ];
+
+    const chartData = mockContributionData.days.map((day) => day.count);
+    const topLanguages = getTopLanguages(mockData.repos, 5);
+
+    if (topLanguages.length === 0) {
+      topLanguages.push({
+        label: 'No Data',
+        value: 1,
+      });
+    }
+
+    const trophyRowY = row2Y + row2Height + LAYOUT.cardGap;
+    const trophyRowHeight = 165;
+
+    const totalHeight = trophyRowY + trophyRowHeight + LAYOUT.padding;
+
+    const content = [
+      renderBackground(width, totalHeight),
+      renderHeader({
+        x: LAYOUT.padding,
+        y: 52,
+        title: `${mockData.name}'s Dashboard`,
+        subtitle: mockData.bio,
+        avatarUrl: mockData.avatarDataUri || mockData.avatarUrl,
+        align: 'left',
+      }),
+
+      renderCardWithStats({
+        x: calculateCardX(0, cardWidth),
+        y: row1Y,
+        width: cardWidth,
+        height: cardHeight,
+        title: card1Title,
+        stats: card1Stats,
+      }),
+      renderCardWithStats({
+        x: calculateCardX(1, cardWidth),
+        y: row1Y,
+        width: cardWidth,
+        height: cardHeight,
+        title: 'Streak Stats',
+        stats: streakStats,
+      }),
+      renderCardWithStats({
+        x: calculateCardX(2, cardWidth),
+        y: row1Y,
+        width: cardWidth,
+        height: cardHeight,
+        title: card3Title,
+        stats: card3Stats,
+      }),
+
+      renderContributionChart({
+        x: LAYOUT.padding,
+        y: row2Y,
+        width: chartWidth,
+        height: row2Height,
+        title: 'Contribution Activity',
+        data: chartData,
+      }),
+      renderDonutChart({
+        x: LAYOUT.padding + chartWidth + LAYOUT.cardGap,
+        y: row2Y,
+        width: row2CardWidth,
+        height: row2Height,
+        title: 'Top Languages',
+        data: topLanguages,
+      }),
+
+      renderTrophyRow({
+        x: LAYOUT.padding,
+        y: trophyRowY,
+        width: fullWidth,
+        height: trophyRowHeight,
+        data: mockTrophyData,
+      }),
+    ].join('\n');
+
+    const svg = wrapSvg(content, width, totalHeight, {
+      title: `${mockData.name}'s Dashboard - ${themeName} Theme`,
+      description: 'GitHub profile statistics dashboard preview',
+    });
+
+    res.setHeader('Content-Type', 'image/svg+xml');
+    res.setHeader('Cache-Control', 'public, max-age=1800');
+    res.send(svg);
+  } catch (error) {
+    console.error('Theme preview render failed:', error.message);
+    res.status(500).send('Error rendering theme preview');
+  }
+});
+
+export default router;

--- a/src/server.js
+++ b/src/server.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { inject } from '@vercel/analytics';
 import profileRoute from './routes/profile.route.js';
+import themeComparisonRoute from './routes/theme-comparison.route.js';
 import { initializeAnalytics } from './services/analytics.service.js';
 import { githubCache } from './utils/cache.js';
 
@@ -59,6 +60,12 @@ app.get('/api/cache/stats', (req, res) => {
 });
 
 app.use('/api/profile', profileRoute);
+app.use('/api/theme-preview', themeComparisonRoute);
+
+// Theme Comparison page
+app.get('/theme-comparison', (req, res) => {
+  res.sendFile(join(__dirname, '..', 'public', 'theme-comparison.html'));
+});
 
 const server = app.listen(PORT, () => {
   if (!IS_PRODUCTION) {


### PR DESCRIPTION
## Description

This PR adds a dedicated Theme Comparison page that allows users to preview and compare all available dashboard themes in one place. Users can now easily explore theme options without manually changing theme parameters and refreshing previews.

## Related Issue

Closes #174

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that causes existing functionality to change)
* [ ] Documentation update
* [ ] Refactor
* [ ] Performance improvement

## Changes Made

* Added a dedicated `/theme-comparison` route for theme exploration.
* Created theme preview cards for all available dashboard themes using mock data.
* Added a "View Theme Comparison" CTA below the Themes section on the landing page.
* Implemented a responsive layout for desktop and mobile devices.
* Improved theme discoverability and comparison experience.

## Testing

* [ ] Ran `npm test` — all tests pass
* [x] Tested manually (if applicable)

### Manual Testing

* Verified navigation from landing page to `/theme-comparison`.
* Verified all theme previews render correctly.
* Tested responsive behavior on different screen sizes.
* Confirmed theme comparison page is accessible through the CTA button.

## Screenshots 

https://github.com/user-attachments/assets/39dd5614-fc5f-4a08-aceb-aac970dbab4f

Screen recording attached demonstrating:

* Landing page CTA
* Theme Comparison page
* Theme preview cards
* Responsive behavior

## Checklist

* [x] My code follows the project's code style
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings or errors
* [ ] I have updated the documentation if necessary
* [x] My changes are scoped to a single issue
