### PR TITLE
Add autocomplete suggestions to theme gallery search

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -261,6 +261,8 @@
           </svg>
           <input type="text" id="themeSearch" class="theme-search-input"
             placeholder="Search themes… e.g. pastel, neon, tokyo" autocomplete="off" />
+          <div class="theme-search-suggestions" id="themeSearchSuggestions" role="listbox"
+            aria-label="Theme search suggestions"></div>
         </div>
         <div class="theme-filter-chips">
           <button class="theme-chip active" data-cat="all">All <span class="chip-count" id="count-all"></span></button>

--- a/public/script.js
+++ b/public/script.js
@@ -655,6 +655,7 @@
     const countEl = document.getElementById('themeResultCount');
     const showMoreBtn = document.getElementById('themeShowMoreBtn');
     const showMoreWrap = document.getElementById('themeShowMoreWrapper');
+    const suggestionsBox = document.getElementById('themeSearchSuggestions');
 
     if (!searchInput || !emptyState || !countEl) return;
 
@@ -666,7 +667,65 @@
 
     let activeCategory = 'all';
     let searchQuery = '';
-    let showingAll = false;   // tracks whether user expanded the list
+    let showingAll = false;
+
+    const themeNames = Array.from(cards).map(card => {
+      const nameEl = card.querySelector('.theme-name');
+      if (!nameEl) return '';
+
+      const nameClone = nameEl.cloneNode(true);
+      nameClone.querySelectorAll('.default-badge').forEach(badge => badge.remove());
+      return nameClone.textContent.trim();
+    }).filter(Boolean);
+
+    function hideSuggestions() {
+      if (!suggestionsBox) return;
+
+      suggestionsBox.innerHTML = '';
+      suggestionsBox.classList.remove('visible');
+      searchInput.setAttribute('aria-expanded', 'false');
+    }
+
+    function selectSuggestion(themeName) {
+      searchInput.value = themeName;
+      searchQuery = themeName.toLowerCase();
+      showingAll = false;
+      filterThemes();
+      hideSuggestions();
+      searchInput.focus();
+    }
+
+    // Render case-insensitive theme-name suggestions as the user types. Empty
+    // queries or queries with no matching names keep the dropdown hidden.
+    function updateSuggestions() {
+      if (!suggestionsBox) return;
+
+      const query = searchInput.value.trim().toLowerCase();
+      if (!query) {
+        hideSuggestions();
+        return;
+      }
+
+      const matches = themeNames.filter(name => name.toLowerCase().includes(query));
+      if (!matches.length) {
+        hideSuggestions();
+        return;
+      }
+
+      suggestionsBox.innerHTML = '';
+      matches.forEach(name => {
+        const item = document.createElement('button');
+        item.type = 'button';
+        item.className = 'theme-search-suggestion';
+        item.setAttribute('role', 'option');
+        item.textContent = name;
+        item.addEventListener('click', () => selectSuggestion(name));
+        suggestionsBox.appendChild(item);
+      });
+
+      suggestionsBox.classList.add('visible');
+      searchInput.setAttribute('aria-expanded', 'true');
+    }
 
     // ── Core filter function ──
     function filterThemes() {
@@ -721,14 +780,11 @@
         countEl.textContent = `Showing ${Math.min(INITIAL_SHOW, visible)} of ${totalCount} themes`;
       }
 
-      // Show/hide the Show More button
-      // Hide it when: filtering is active, or all cards already visible
       if (isFiltering || visible <= INITIAL_SHOW) {
         showMoreWrap.style.display = 'none';
       } else {
         showMoreWrap.style.display = 'flex';
         showMoreBtn.textContent = showingAll ? 'Show Less' : `Show All Themes (${visible})`;
-        // re-attach the arrow SVG since we overwrote textContent
         showMoreBtn.innerHTML = showingAll
           ? `Show Less <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>`
           : `Show All Themes (${visible}) <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>`;
@@ -741,8 +797,6 @@
       showMoreBtn.addEventListener('click', () => {
         showingAll = !showingAll;
         filterThemes();
-
-        // If collapsing back to 5, scroll up to themes section
         if (!showingAll) {
           document.getElementById('themes')
             .scrollIntoView({ behavior: 'smooth', block: 'start' });
@@ -755,6 +809,16 @@
       searchQuery = e.target.value.trim().toLowerCase();
       showingAll = false;  // reset expansion on new search
       filterThemes();
+      updateSuggestions();
+    });
+
+    searchInput.addEventListener('focus', updateSuggestions);
+
+    // Close autocomplete when the user clicks away from the search area.
+    document.addEventListener('click', e => {
+      if (!searchInput.parentElement.contains(e.target)) {
+        hideSuggestions();
+      }
     });
 
     // ── Chip clicks ──

--- a/public/styles.css
+++ b/public/styles.css
@@ -1868,6 +1868,55 @@ html {
   position: relative;
 }
 
+.theme-search-suggestions {
+  position: absolute;
+  z-index: 30;
+  top: calc(100% + 0.4rem);
+  left: 0;
+  right: 0;
+  display: none;
+  max-height: 240px;
+  overflow-y: auto;
+  padding: 0.35rem;
+  background: rgba(17, 24, 39, 0.98);
+  border: 1px solid rgba(139, 92, 246, 0.28);
+  border-radius: 8px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.36);
+}
+
+.theme-search-suggestions.visible {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.theme-search-suggestion {
+  width: 100%;
+  padding: 0.65rem 0.8rem;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: 0.95rem;
+  line-height: 1.3;
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--transition-base), color var(--transition-base);
+}
+
+.theme-search-suggestion:hover,
+.theme-search-suggestion:focus-visible {
+  background: rgba(124, 58, 237, 0.16);
+  color: var(--text-primary);
+  outline: none;
+}
+
+.light-theme .theme-search-suggestions {
+  background: rgba(255, 255, 255, 0.98);
+  border-color: rgba(124, 58, 237, 0.22);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.14);
+}
+
 .theme-search-icon {
   position: absolute;
   left: 1rem;


### PR DESCRIPTION
## Description

Added autocomplete search suggestions to the theme gallery search to improve theme discovery and navigation. Users now receive real-time theme name suggestions while typing and can quickly select a suggestion to apply the existing search filter.

## Related Issue

Closes #180

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that causes existing functionality to change)
* [ ] Documentation update
* [ ] Refactor
* [ ] Performance improvement

## Changes Made

* Added a suggestion dropdown below the theme search input.
* Implemented real-time, case-insensitive autocomplete suggestions using existing theme card data.
* Reused the existing `filterThemes()` logic when a suggestion is selected.
* Added automatic dropdown closing on empty input, no matches, and outside clicks.
* Styled the suggestion dropdown for both dark and light themes.

## Testing

* [ ] Ran `npm test` — all tests pass
* [x] Tested manually (if applicable)

Manual testing performed:

* Verified suggestions appear while typing.
* Verified suggestions update dynamically based on user input.
* Verified clicking a suggestion fills the search field and filters themes correctly.
* Verified dropdown closes when the input is empty.
* Verified dropdown closes when no matching themes are found.
* Verified dropdown closes when clicking outside the search area.
* Verified JavaScript syntax using:

```powershell
node --check public\script.js
```

## Screenshots (if applicable)

<img width="1571" height="698" alt="image" src="https://github.com/user-attachments/assets/b6eef77f-aa68-439b-b1e7-2fd704d959ee" />
<img width="1767" height="572" alt="image" src="https://github.com/user-attachments/assets/f8a45364-7f5e-4fef-b96e-0b27b54fb2d0" />


## Checklist

* [x] My code follows the project's code style
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings or errors
* [ ] I have updated the documentation if necessary
* [x] My changes are scoped to a single issue
