### PR TITLE
fix: resolve duplicate HTML IDs in public/index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -748,14 +748,14 @@
           <h3 class="usage-title">Basic Usage</h3>
           <p class="usage-description">Simply add this to your GitHub README.md:</p>
           <div class="code-wrapper">
-            <button id="copy-btn" class="copy-btn">
+            <button class="copy-btn">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
                 <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
               </svg>
             </button>
             <pre
-              class="code-block"><code id="snippet">![samdev-pulse](https://samdev-pulse.vercel.app/api/profile?username=YOUR_USERNAME)</code></pre>
+              class="code-block"><code>![samdev-pulse](https://samdev-pulse.vercel.app/api/profile?username=YOUR_USERNAME)</code></pre>
           </div>
         </div>
 
@@ -764,7 +764,7 @@
           <h3 class="usage-title">With Theme</h3>
           <p class="usage-description">Customize with your favorite color scheme:</p>
           <div class="code-wrapper">
-            <button id="copy-btn" class="copy-btn">
+            <button class="copy-btn">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
                 <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
@@ -779,7 +779,7 @@
           <h3 class="usage-title">With CP Stats</h3>
           <p class="usage-description">Show off your competitive programming stats:</p>
           <div class="code-wrapper">
-            <button id="copy-btn" class="copy-btn">
+            <button class="copy-btn">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
                 <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
@@ -794,7 +794,7 @@
           <h3 class="usage-title">Full Customization</h3>
           <p class="usage-description">Combine all options for maximum impact:</p>
           <div class="code-wrapper">
-            <button id="copy-btn" class="copy-btn">
+            <button class="copy-btn">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
                 <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />


### PR DESCRIPTION
## Description

Fixed invalid HTML where multiple elements shared the same `id` attribute. The Preview section's `id="copy-btn"` and `id="snippet"` were duplicated across 4 Usage cards. This caused `document.getElementById()` to only return the first match, breaking expected behavior.

Removed the duplicate IDs from the Usage cards (they still have `class="copy-btn"` for styling/JS selection). No JavaScript changes needed — `script.js` already uses class-based selectors (`.copy-btn`, `.code-wrapper`, `.code-section`) for the copy functionality.

## Related Issue

Closes #167

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement

## Changes Made

- Removed duplicate `id="copy-btn"` from 4 Usage cards (kept `class="copy-btn"`)
- Removed duplicate `id="snippet"` from Usage card 1 (kept as plain `<code>`)
- Retained `id="copy-btn"` and `id="snippet"` in the Preview section (the intended primary elements)

## Testing

- [X] Ran `npm test` — all 172 tests pass across 12 suites (28 snapshots pass)
- [ ] Tested manually (if applicable)

## Screenshots (if applicable)

N/A — HTML structure change only, no visual difference.

## Checklist

- [X] My code follows the project's code style
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [X] I have updated the documentation if necessary
- [X] My changes are scoped to a single issue