### PR TITLE
fix: sanitize error messages in CodeChef and Codeforces services

### DIFF
--- a/src/services/codechef.service.js
+++ b/src/services/codechef.service.js
@@ -39,6 +39,6 @@ export async function getCodeChefData(handle) {
       }
     };
   } catch (err) {
-    return { success: false, error: err.message };
+    return { success: false, error: "CodeChef API error" };
   }
 }

--- a/src/services/codeforces.service.js
+++ b/src/services/codeforces.service.js
@@ -48,6 +48,6 @@ export async function getCodeforcesData(handle) {
       }
     };
   } catch (err) {
-    return { success: false, error: err.message };
+    return { success: false, error: "Codeforces API error" };
   }
 }


### PR DESCRIPTION
## Summary

This PR improves error handling in the CodeChef and Codeforces services by preventing raw exception messages from being returned to clients.

Previously, both services exposed `err.message` directly from catch blocks. While useful for debugging, these messages can reveal internal implementation details, third-party API responses, or other information that should not be surfaced to users.

To align with the existing error-handling approach used throughout the services, generic and user-friendly error messages are now returned instead.

# Closes #194

## Changes Made

### `src/services/codechef.service.js`

* Replaced `err.message` with `'CodeChef API error'`

### `src/services/codeforces.service.js`

* Replaced `err.message` with `'Codeforces API error'`

## Example

### Before

```js
} catch (err) {
  return { success: false, error: err.message };
}
```

### After

```js
} catch (err) {
  return { success: false, error: 'CodeChef API error' };
}
```

A similar change has been applied to the Codeforces service.

## Why This Change?

* Prevents accidental exposure of internal error details
* Avoids leaking third-party API responses to clients
* Keeps error responses consistent across the codebase
* Follows the existing pattern already used for cases such as API timeouts and user-not-found scenarios

## Testing

Verified that all existing tests continue to pass without any changes:

* `codechef.service.test.js` — 18/18 passing
* `codeforces.service.test.js` — 11/11 passing

## Type of Change

* [x] Bug fix
* [x] Security improvement
