### PR TITLE
fix: return JSON instead of plain text on theme-comparison error

### DIFF
--- a/src/routes/theme-comparison.route.js
+++ b/src/routes/theme-comparison.route.js
@@ -206,7 +206,7 @@ router.get('/:themeName', (req, res) => {
     res.send(svg);
   } catch (error) {
     console.error('Theme preview render failed:', error.message);
-    res.status(500).send('Error rendering theme preview');
+    res.status(500).json({ error: 'Error rendering theme preview'});
   }
 });
 


### PR DESCRIPTION
## Summary

This PR fixes an inconsistency in the error response format of the theme comparison route.

Previously, internal server errors in `theme-comparison.route.js` returned a plain text response using `.send()`, while the rest of the API follows a JSON-based response structure for both successful and failed requests. This could lead to inconsistent handling on the client side and makes the API contract less predictable.

# Closes #193

## Changes Made

### `src/routes/theme-comparison.route.js`

* Replaced the plain text error response with a structured JSON response
* Preserved the existing error message content
* Ensured the response is returned with the correct `application/json` content type

## Example

### Before

```js id="1j4v7a"
res.status(500).send('Error rendering theme preview');
```

### After

```js id="w8m2kp"
res.status(500).json({
  error: 'Error rendering theme preview'
});
```

## Why This Change?

* Keeps API responses consistent across the application
* Makes error handling more predictable for API consumers
* Returns the appropriate JSON content type for error responses
* Aligns this route with existing API response patterns

## Testing

There are currently no automated tests covering this route.

Manually verified that:

* The route still returns HTTP 500 on internal errors
* The error message content remains unchanged
* The response body is now returned as structured JSON
* The response uses the `application/json` content type

## Type of Change

* [x] Bug fix
