### PR TITLE
docs: remove invalid backslash escapes from preview url query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ You can customize the dashboard colors directly by passing hex values (without `
 
 ### Preview
 
-![samdev-pulse full preview](https://samdev-pulse.vercel.app/api/profile?username=SamXop123\&theme=oceanicnext\&align=center\&leetcode=fjzzq2002\&codeforces=tourist\&codechef=tourist)
+![samdev-pulse full preview](https://samdev-pulse.vercel.app/api/profile?username=SamXop123&theme=oceanicnext&align=center&leetcode=fjzzq2002&codeforces=tourist&codechef=tourist)
 
 ---
 


### PR DESCRIPTION
## Description

This PR fixes a malformed URL in the "Full Example Preview" section of the `README.md`. Previously, the ampersands in the query string were escaped (`\&`). In standard Markdown image syntax, this causes the backslashes to be evaluated as literal characters within the URL. Consequently, the backend would receive malformed query values (e.g., `username=SamXop123\`), which breaks parameter parsing and causes a server error. Removing the escapes ensures the example URL functions correctly when users click or copy it.

## Related Issue

Closes #202

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Refactor
- [ ] Performance improvement

## Changes Made

- Removed invalid backslash escapes (`\`) preceding the ampersands (`&`) in the Full Example preview URL.
- Ensured the markdown image link evaluates properly without appending literal backslashes to the backend query parameters.

## Testing

- [ ] Ran `npm test` — all tests pass
- [x] Tested manually (verified the URL correctly resolves without the backslashes and passes markdown linting)

## Screenshots (if applicable)

*Not applicable. This is a documentation-only update to the README.*

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation if necessary
- [x] My changes are scoped to a single issue