### PR TITLE
feat: add active section highlighting for navbar navigation (#207)

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -885,3 +885,44 @@
     initThemeFilter();
   }
 })();
+
+// Active Section Highlighting for Navbar
+(function () {
+  'use strict';
+
+  function initScrollSpy() {
+    const sections = document.querySelectorAll('section[id]');
+    const navLinks = document.querySelectorAll('.navbtn a.nav-link');
+
+    if (!sections.length || !navLinks.length) return;
+
+    const observer = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            navLinks.forEach(function (link) {
+              link.classList.remove('active');
+              if (link.getAttribute('href') === '#' + entry.target.id) {
+                link.classList.add('active');
+              }
+            });
+          }
+        });
+      },
+      {
+        rootMargin: '-80px 0px -50% 0px',
+        threshold: 0,
+      }
+    );
+
+    sections.forEach(function (section) {
+      observer.observe(section);
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initScrollSpy);
+  } else {
+    initScrollSpy();
+  }
+})();

--- a/public/styles.css
+++ b/public/styles.css
@@ -2057,6 +2057,13 @@ html {
   width: 100%;
 }
 
+.navbtn ul li a.active {
+  color: var(--accent-purple);
+}
+
+.navbtn ul li a.active::after {
+  width: 100%;
+}
 
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Fixes #207

Adds scroll-spy functionality using IntersectionObserver to highlight the active navbar link based on which section is currently visible.

## Changes
- **script.js**: New `initScrollSpy` function using IntersectionObserver with `rootMargin: -80px 0px -50% 0px` to account for fixed navbar height
- **styles.css**: `.nav-link.active` gets purple color and visible underline bar (reuses existing `::after` animation)

## Sections tracked
Home, Features, Themes, Try It Live, Guide, About