### PR TITLE
batch: add caching to codeforces and codechef services (#216)

### DIFF
--- a/src/services/codechef.service.js
+++ b/src/services/codechef.service.js
@@ -1,4 +1,5 @@
 import { HttpErrorCode, httpRequest } from '../utils/http-client.js';
+import { githubCache } from '../utils/cache.js';
 
 function getDivision(rating) {
   if (rating >= 2000) return 'Div 1';
@@ -8,6 +9,10 @@ function getDivision(rating) {
 }
 
 export async function getCodeChefData(handle) {
+  const cacheKey = `codechef:${handle}`;
+  const cached = githubCache.get(cacheKey);
+  if (cached) return cached;
+
   try {
     const safeHandle = encodeURIComponent(handle);
 
@@ -27,7 +32,7 @@ export async function getCodeChefData(handle) {
 
     const currentRating = data.rating_number ?? 0;
 
-    return {
+    const result = {
       success: true,
       data: {
         handle: data.username ?? handle,
@@ -38,6 +43,8 @@ export async function getCodeChefData(handle) {
         division: getDivision(currentRating),
       }
     };
+    githubCache.set(cacheKey, result);
+    return result;
   } catch (err) {
     return { success: false, error: err.message };
   }

--- a/src/services/codeforces.service.js
+++ b/src/services/codeforces.service.js
@@ -1,6 +1,10 @@
 import { HttpErrorCode, httpRequest } from '../utils/http-client.js';
+import { githubCache } from '../utils/cache.js';
 
 export async function getCodeforcesData(handle) {
+  const cacheKey = `codeforces:${handle}`;
+  const cached = githubCache.get(cacheKey);
+  if (cached) return cached;
   try {
     const safeHandle = encodeURIComponent(handle);
 
@@ -36,7 +40,7 @@ export async function getCodeforcesData(handle) {
       problemsSolved = solved.size;
     }
 
-    return {
+    const result = {
       success: true,
       data: {
         handle: user.handle,
@@ -47,6 +51,8 @@ export async function getCodeforcesData(handle) {
         problemsSolved,
       }
     };
+    githubCache.set(cacheKey, result);
+    return result;
   } catch (err) {
     return { success: false, error: err.message };
   }


### PR DESCRIPTION
Closes #216

Add in-memory TTL caching for Codeforces and CodeChef API responses, reducing redundant upstream calls and improving dashboard render time for repeated profile views.

Co-authored-by: none