### PR TITLE
fix: restore dark/light theme toggle functionality

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -22,6 +22,8 @@
   }
 
   function applyTheme(theme) {
+    console.log("applyTheme:", theme);
+
     const isLight = theme === LIGHT_THEME;
     document.documentElement.classList.remove('light-theme-pending');
     document.body.classList.toggle('light-theme', isLight);
@@ -32,8 +34,7 @@
       toggle.setAttribute('aria-label', isLight ? 'Switch to dark theme' : 'Switch to light theme');
       toggle.title = isLight ? 'Switch to dark theme' : 'Switch to light theme';
     }
-    addRecentTheme(theme);
-    renderQuickThemeSections();
+    
   }
 
   function initThemeToggle() {
@@ -43,9 +44,17 @@
     applyTheme(savedTheme === LIGHT_THEME ? LIGHT_THEME : 'dark');
 
     if (!toggle) return;
-
+    console.log("Theme toggle initialized");
     toggle.addEventListener('click', function () {
-      const nextTheme = document.body.classList.contains('light-theme') ? 'dark' : LIGHT_THEME;
+      console.log("Toggle clicked");
+
+      const nextTheme =
+        document.body.classList.contains('light-theme')
+          ? 'dark'
+          : LIGHT_THEME;
+
+      console.log("Next theme:", nextTheme);
+
       applyTheme(nextTheme);
       storeTheme(nextTheme);
     });

--- a/public/script.js
+++ b/public/script.js
@@ -22,8 +22,7 @@
   }
 
   function applyTheme(theme) {
-    console.log("applyTheme:", theme);
-
+    
     const isLight = theme === LIGHT_THEME;
     document.documentElement.classList.remove('light-theme-pending');
     document.body.classList.toggle('light-theme', isLight);
@@ -44,16 +43,14 @@
     applyTheme(savedTheme === LIGHT_THEME ? LIGHT_THEME : 'dark');
 
     if (!toggle) return;
-    console.log("Theme toggle initialized");
+    
     toggle.addEventListener('click', function () {
-      console.log("Toggle clicked");
 
       const nextTheme =
         document.body.classList.contains('light-theme')
           ? 'dark'
           : LIGHT_THEME;
 
-      console.log("Next theme:", nextTheme);
 
       applyTheme(nextTheme);
       storeTheme(nextTheme);


### PR DESCRIPTION
### Description
This PR fixes the dark/light theme toggle not switching the application theme.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made
- Removed the unintended dependency between the website theme toggle and the recent/favorite themes feature.
- Restored immediate dark/light theme switching.
- Preserved theme preference across page reloads.
- Ensured Favorites and Recent Themes continue to function independently.

### Testing
- [x] Tested manually

### Manual Verification
- Verified dark/light theme switches immediately on toggle.
- Verified selected theme persists after page refresh.
- Verified no JavaScript runtime errors occur.
- Verified Favorites and Recent Themes continue working correctly.

### Screenshots
1. Light-theme enabled.
<img width="636" height="872" alt="Screenshot 2026-07-08 010830" src="https://github.com/user-attachments/assets/06215f8e-d230-4594-af09-0dc1751dcb51" />


### Checklist
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] My changes are scoped to a single issue

### Related Issue
Closes #228